### PR TITLE
Use DocStringExtensions to remove manual types and signatures 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Peter Wolf", "Julia Community"]
 version = "0.1.0"
 
 [deps]
+DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
 Infiltrator = "5903a43b-9cc3-4c30-8d17-598619ec4e9b"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/docs/src/core/torch-core.md
+++ b/docs/src/core/torch-core.md
@@ -16,7 +16,7 @@ There are also several dataset types that represent combinations of datasets. If
 ```@docs
 FastAI.ConcatDataset
 FastAI.ChainDataset
-FastAI.++
+FastAI.:++
 ```
 
 Lastly, we can also take random and fixed subsets of a [`MapDataset`](@ref).

--- a/src/FastAI.jl
+++ b/src/FastAI.jl
@@ -1,4 +1,4 @@
-#=
+#= 
 FastAI.jl:
 
 Author: Peter Wolf (opus111@gmail.com)
@@ -16,6 +16,7 @@ using Zygote
 using Infiltrator
 using Base: length, getindex
 using Random: randperm
+using DocStringExtensions
 
 export AbstractLearner
 export AbstractCallback
@@ -48,6 +49,18 @@ export reset
 export accumulate
 export value
 export name
+
+@template (FUNCTIONS, METHODS) = 
+    """
+    $(TYPEDSIGNATURES)
+    $(DOCSTRING)
+    """
+
+@template (TYPES) =
+    """
+    $(TYPEDEF)
+    $(DOCSTRING)
+    """
 
 include("dataset.jl")
 include("databunch.jl")

--- a/src/databunch.jl
+++ b/src/databunch.jl
@@ -1,5 +1,4 @@
 """
-    DataBunch
     DataBunch(train::Flux.Data.DataLoader, valid::Flux.Data.DataLoader)
 
 A `DataBunch` is a bunched `train` and `valid` (validation) dataloader.
@@ -10,14 +9,10 @@ struct DataBunch
 end
 
 """
-    train(db::DataBunch)
-
 Get the `db.train` dataloader.
 """
 train(db::DataBunch) = db.train
 """
-    valid(db::DataBunch)
-
 Get the `db.valid` (validation) dataloader.
 """
 valid(db::DataBunch) = db.valid

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -6,8 +6,6 @@ To make it work with a map-style dataset with non-integral indices/keys,
 =#
 
 """
-    IterableDataset
-
 Every dataset is an `IterableDataset` representing an iterable of data samples.
 `IterableDataset` is particularly useful when data come from a stream.
 
@@ -23,8 +21,6 @@ See Julia iteration documentation for more information
 abstract type IterableDataset end
 
 """
-    MapDataset <: IterableDataset
-
 Some datasets are also `MapDataset`s that map integer ids to data samples.
 All `MapDatasets` are also [`IterableDatasets`](@ref).
 
@@ -41,7 +37,6 @@ Base.firstindex(md::T) where T <: MapDataset = 1
 Base.lastindex(md::T) where T <: MapDataset = length(md)
 
 """
-    ConcatDataset <: MapDataset
     ConcatDataset(ds1::MapDataset, ds2::MapDataset)
 
 Two [`MapDataset`](@ref)s concatenated together.
@@ -66,7 +61,6 @@ function Base.getindex(cd::ConcatDataset, rng::UnitRange)
 end
 
 """
-    ChainDataset <: IterableDataset
     ChainDataset(ds1::IterableDataset, ds2::IterableDataset)
 
 A sequence of [`IterableDataset`](@ref)s.
@@ -88,14 +82,10 @@ end
 
 
 """
-    ++(ds1::MapDataset, ds2::MapDataset)
-
 Concatenate two [`MapDataset`](@ref)s into a [`ConcatDataset`](@ref).
 """
 ++(ds1::MapDataset, ds2:: MapDataset) = ConcatDataset(ds1,ds2)
 """
-    ++(ds1::IterableDataset, ds2::IterableDataset)
-
 Combine two or more [`IterableDataset`](@ref)s into [`ChainDataset`](@ref).
 *Note*: if all the datasets are [`MapDataset`](@ref)s, then the result is a [`ConcatDataset`](@ref),
   but any other combination will result in a [`ChainDataset`](@ref).
@@ -104,8 +94,6 @@ Combine two or more [`IterableDataset`](@ref)s into [`ChainDataset`](@ref).
 ++(ds1::IterableDataset, ds2::IterableDataset, ds3...) = foldl(++, (ds2 , ds3...), init=ds1)
 
 """
-    SubsetDataset <: MapDataset
-
 A subset of a [`MapDataset`](@ref).
 """
 struct SubsetDataset <: MapDataset
@@ -120,16 +108,12 @@ Base.length(sd::SubsetDataset) = length(sd.idxs)
 Base.getindex(sd::SubsetDataset, idx::Int) = sd.ds[sd.idxs[idx]]
 Base.getindex(sd::SubsetDataset, rng::UnitRange) = [sd[i] for i in sd.idxs[rng]]
 """
-    subset(dataset::MapDataset, indices::Array{Int})
-
 A [`SubsetDataset`](@ref) of `dataset` at `indices`.
 """
 subset(dataset::MapDataset, indices::Array{Int}) = SubsetDataset(dataset,indices)
 
 
 """
-    random_split(dataset::MapDataset, lengths::Array{Int})
-
 Randomly split `dataset` into non-overlapping new [`SubsetDataset`](@ref)s of given `lengths`.
 """
 function random_split(dataset::MapDataset, lengths::Array{Int})

--- a/src/learner.jl
+++ b/src/learner.jl
@@ -69,8 +69,6 @@ struct CancelEpochValidateException <: Exception end
 struct CancelBatchValidateException <: Exception end
 
 """
-    AbstractLearner
-
 An `AbstractLearner` groups together a model, train and validate data,
   optimizer, loss function and callbacks.
 
@@ -93,7 +91,6 @@ Callbacks receive epoch, batch and loss information which they may pass on to [M
 abstract type AbstractLearner end
 
 """
-    Learner <: AbstractLearner
     Learner(data_bunch, model; opt = Flux.ADAM(), loss = Flux.mse)
 
 A `Learner` is the standard grouping of a data bunch, model, optimizer, and loss.
@@ -108,66 +105,46 @@ end
 Learner(data_bunch, model; opt=Flux.ADAM(), loss=Flux.mse) = Learner([],data_bunch,model,opt,loss)
 
 """
-    data_bunch(l::Learner)
-
 Get the data bunch for `l`.
 """
 data_bunch(l::Learner) = l.db
 """
-    data_bunch!(l::Learner, data_bunch)
-
 Set the data bunch for `l` to `data_bunch`.
 """
 data_bunch!(l::Learner, data_bunch) = l.db = data_bunch
 
 """
-    model(l::Learner)
-
 Get the model for `l`.
 """
 model(l::Learner) = l.model
 """
-    model!(l::Learner, model)
-
 Set the model for `l` to `model`.
 """
 model!(l::Learner, model) = l.model = model
 
 """
-    loss(l::Learner)
-
 Get the loss for `l`.
 """
 loss(l::Learner) = l.loss
 """
-    loss!(l::Learner, loss)
-
 Set the loss for `l` to `loss`.
 """
 loss!(l::Learner,loss) = l.loss = loss
 
 """
-    opt(l::Learner)
-
 Get the optimizer for `l`.
 """
 opt(l::Learner) = l.opt
 """
-    opt!(l::Learner, opt)
-
 Set the optimizer for `l` to `opt`.
 """
 opt!(l::Learner,opt) = l.opt=opt
 
 """
-    add_cb!(learner::Learner, cb::AbstractCallback)
-
 Add `cb` to the list of callbacks for `learner`.
 """
 add_cb!(learner::Learner,cb::AbstractCallback) = push!(learner.cbs,cb)
 """
-    cbs(learner::Learner)
-
 Get the list of callbacks for `learner`.
 """
 cbs(learner::Learner) = learner.cbs

--- a/src/recorder.jl
+++ b/src/recorder.jl
@@ -29,7 +29,6 @@ https://dev.fast.ai/learner#Recorder
 =#
 
 """
-    Recorder
     Recorder(learn::Learner; train_loss = true, train_smooth_loss = true,
                              validate_loss = true, validate_smooth_loss = true)
 
@@ -67,15 +66,11 @@ function Recorder(learn::Learner; train_loss = true, train_smooth_loss = true,
 end
 
 """
-    add!(rec::Recorder, name, epoch_count, batch_size)
-
 Add `name` to `rec` to be tracked.
 """
 add!(rec::Recorder, name, epoch_count, batch_size) = rec.logs[name] = fill(nothing,epoch_count,batch_size)
 
 """
-    log!(rec::Recorder, name::String, epoch::Int, batch::Int, value)
-
 Log `value` to `rec[name, epoch, batch]`.
 """
 function log!(rec::Recorder, name::String, epoch::Int, batch::Int, value)


### PR DESCRIPTION
This should cut down on the work required to maintain type signatures over time. No new docs have been added, so happy to rebase after #10 has landed. 