### PR TITLE
new tutorial: Migration guide from fastai's python library to FastAI.jl

### DIFF
--- a/docs/notebooks/Migration_Guide_beginner.ipynb
+++ b/docs/notebooks/Migration_Guide_beginner.ipynb
@@ -29,7 +29,7 @@
       "source": [
         "# Migration Guide from FastAI's python library to FastAI.jl - Beginner\n",
         "\n",
-        "If you are a user of Fastai's python library and want to migrate to FastAI.jl, this three part tutorial series will get you started. In this first part of tutorial we'll see about **Datasets**, **dataloaders** and **Learner** objects of FastAI.jl"
+        "If you are a user of Fastai's python library and want to migrate to FastAI.jl, this three part tutorial series will get you started. In this first part of tutorial, we'll look at **datasets**, **dataloaders** and **learner** in FastAI.jl"
       ]
     },
     {

--- a/docs/notebooks/Migration_Guide_beginner.ipynb
+++ b/docs/notebooks/Migration_Guide_beginner.ipynb
@@ -374,7 +374,7 @@
         "id": "bdx1u49NFxjj"
       },
       "source": [
-        "Learner is the object that binds the data loaders with the model and sets the other hyper parameters like loss function, optimizers, etc. There is `Learner()` function which is similar to fastai's `cnn_learner` function. The below python code can be translated as,\n",
+        "The learner is the object that binds the data loaders with the model and sets the other hyper parameters like loss function, optimizers, etc. There is `Learner()` function which is similar to fastai's `cnn_learner` function. The below python code can be translated as,\n",
         "\n",
         "```\n",
         "learn = cnn_learner(dls, resnet34, metrics=error_rate)\n",

--- a/docs/notebooks/Migration_Guide_beginner.ipynb
+++ b/docs/notebooks/Migration_Guide_beginner.ipynb
@@ -52,7 +52,7 @@
       "source": [
         "# Datasets\n",
         "\n",
-        "All of the fastai datasets are available in FastAI.jl. In fastai's python library you would have to download the image files first and read their paths and feed them to dataloaders. FastAI.jl simplifies this task into single step. ```Datasets.loadtaskdata()``` function takes two inputs - path of dataset and type of the task (Classification or Segmentation) and gives out Julia version of dataloaders.\n",
+        "All of the fastai datasets are available in FastAI.jl. In fastai's python library you would have to download the image files first and read their paths and feed them to dataloaders. FastAI.jl simplifies this task into single step. ```Datasets.loadtaskdata()``` function takes two inputs - path of dataset and type of the task (image classification or segmentation) and gives out Julia version of dataloaders.\n",
         "\n",
         "So the following code in python translates to:\n",
         "```\n",

--- a/docs/notebooks/Migration_Guide_beginner.ipynb
+++ b/docs/notebooks/Migration_Guide_beginner.ipynb
@@ -441,7 +441,7 @@
         "id": "04tgsb-GL3eM"
       },
       "source": [
-        "wehre `classnames` is a vector consists of names of classes in whole dataset and `image_size` is a tuple with length and breadth of images."
+        "where `classnames` is a vector consists of names of classes in whole dataset and `image_size` is a tuple with length and breadth of images."
       ]
     }
   ]

--- a/docs/notebooks/Migration_Guide_beginner.ipynb
+++ b/docs/notebooks/Migration_Guide_beginner.ipynb
@@ -430,7 +430,7 @@
         "finetune!(learn, 1)\n",
         "\n",
         "# to fit one cycle\n",
-        "fitonecycle!(learn,1)"
+        "fitonecycle!(learn, 1)"
       ],
       "execution_count": null,
       "outputs": []

--- a/docs/notebooks/Migration_Guide_beginner.ipynb
+++ b/docs/notebooks/Migration_Guide_beginner.ipynb
@@ -1,0 +1,448 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "name": "Migration_Guide_beginner.ipynb",
+      "provenance": [],
+      "collapsed_sections": [],
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Julia",
+      "language": "julia",
+      "name": "julia"
+    },
+    "language_info": {
+      "file_extension": ".jl",
+      "mimetype": "application/julia",
+      "name": "julia"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "M_1M6h-7M2xO"
+      },
+      "source": [
+        "# Migration Guide from FastAI's python library to FastAI.jl - Beginner\n",
+        "\n",
+        "If you are a user of Fastai's python library and want to migrate to FastAI.jl, this three part tutorial series will get you started. In this first part of tutorial we'll see about **Datasets**, **dataloaders** and **Learner** objects of FastAI.jl"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "22CaKZYa6cwN"
+      },
+      "source": [
+        "using FastAI\n",
+        "using FastAI.Datasets"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "7m6ICZnqtgq1"
+      },
+      "source": [
+        "# Datasets\n",
+        "\n",
+        "All of the fastai datasets are available in FastAI.jl. In fastai's python library you would have to download the image files first and read their paths and feed them to dataloaders. FastAI.jl simplifies this task into single step. ```Datasets.loadtaskdata()``` function takes two inputs - path of dataset and type of the task (Classification or Segmentation) and gives out Julia version of dataloaders.\n",
+        "\n",
+        "So the following code in python translates to:\n",
+        "```\n",
+        "path = untar_data(URLs.PETS)\n",
+        "files = get_image_files(path/\"images\")\n",
+        "dls = ImageDataLoaders.from_name_func(path, files, label_func, item_tfms=Resize(224))\n",
+        "```"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "2HYP1rzuOpR5",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "b221de78-a3bc-4d16-90fb-e68ceb223740"
+      },
+      "source": [
+        "# Julia Code\n",
+        "data = Datasets.loadtaskdata(Datasets.datasetpath(\"imagenette2-160\"), ImageClassificationTask)"
+      ],
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "This program has requested access to the data dependency fastai-imagenette2-160.\n",
+            "which is not currently installed. It can be installed automatically, and you will not see this message again.\n",
+            "\n",
+            "\"imagenette2-160\" from the fastai dataset repository (https://course.fast.ai/datasets)\n",
+            "\n",
+            "\n",
+            "\n",
+            "Download size: ???\n",
+            "\n",
+            "\n",
+            "\n",
+            "Do you want to download the dataset from https://s3.amazonaws.com/fast-ai-imageclas/imagenette2-160.tgz to \"/root/.julia/datadeps/fastai-imagenette2-160\"?\n",
+            "[y/n]\n",
+            "stdin> y\n"
+          ],
+          "name": "stdout"
+        },
+        {
+          "output_type": "stream",
+          "text": [
+            "┌ Info: Downloading\n",
+            "│   source = https://s3.amazonaws.com/fast-ai-imageclas/imagenette2-160.tgz\n",
+            "│   dest = /root/.julia/datadeps/fastai-imagenette2-160/imagenette2-160.tgz\n",
+            "│   progress = 1.0\n",
+            "│   time_taken = 2.49 s\n",
+            "│   time_remaining = 0.0 s\n",
+            "│   average_speed = 37.858 MiB/s\n",
+            "│   downloaded = 94.417 MiB\n",
+            "│   remaining = 0 bytes\n",
+            "│   total = 94.417 MiB\n",
+            "└ @ HTTP /root/.julia/packages/HTTP/cxgat/src/download.jl:119\n"
+          ],
+          "name": "stderr"
+        },
+        {
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "7-Zip (a) [64] 16.02 : Copyright (c) 1999-2016 Igor Pavlov : 2016-05-21\n",
+            "p7zip Version 16.02 (locale=en_US.UTF-8,Utf16=on,HugeFiles=on,64 bits,2 CPUs Intel(R) Xeon(R) CPU @ 2.20GHz (406F0),ASM,AES-NI)\n",
+            "\n",
+            "\n",
+            "Extracting archive: \n",
+            "--\n",
+            "Path = \n",
+            "Type = tar\n",
+            "Code Page = UTF-8\n",
+            "\n",
+            "Everything is Ok\n",
+            "\n",
+            "Folders: 23\n",
+            "Files: 13397\n",
+            "Size:       107794109\n",
+            "Compressed: 6872064\n"
+          ],
+          "name": "stdout"
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "mapobs((input = FastAI.Datasets.loadfile, target = FastAI.Datasets.var\"#27#32\"()), DataSubset(::FileDataset, ::Vector{Int64}, ObsDim.Undefined())\n",
+              " 13394 observations)"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 9
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "OGOkrUK1y3D-"
+      },
+      "source": [
+        "```datasetpath()``` function downloads the given dataset and returns the path of the dataset. It consists of all FastAI datasets from python. Each dataset is referred by an unique keyword. The keywords for common datasets are,\n",
+        "\n",
+        "|                      Dataset                      |      Keyword      |\n",
+        "|:-------------------------------------------------:|:-----------------:|\n",
+        "|                       MNIST                       |    \"mnist-png\"    |\n",
+        "|                      CIFAR10                      |     \"cifar10\"     |\n",
+        "|                      Food 101                     |     \"food-101\"    |\n",
+        "|                  Oxford-IIIT Pets                 | \"oxford-iiit-pet\" |\n",
+        "|                     Imagenette                    |    \"imagenette\"   |\n",
+        "|                     Imagewang                     |    \"imagewang\"    |\n",
+        "|                     Imagewoof                     |    \"imagewoof\"    |\n",
+        "|            IMDB Large Movie review data           |       \"imdb\"      |\n",
+        "|                    Wikitext-103                   |   \"wikitext-103\"  |\n",
+        "| CamVid: Motion based Segmentation and Recognition |      \"camvid\"     |\n",
+        "|           PASCAL: Visual Object Classes           |    \"pascal-voc\"   |"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "EmDKNgh2A3Dp"
+      },
+      "source": [
+        "# DataLoaders"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "fFmwN26ZA5wO"
+      },
+      "source": [
+        "Dataloaders are important aspects of fastai's python library. These objects are like assembly lines that feed materials to the machine. Likewise dataloaders feed data to the model. \n",
+        "\n",
+        "Though there is dataloader object in FastAI.jl, we can skip the complexity of creating separate training and validation dataloaders by using data container object and using ```methodlearner()``` function (more below)\n",
+        "\n",
+        "## To convert fastai datasets\n",
+        "\n",
+        "As dicussed above fastai datasets downloaded using ```loadtaskdata()``` function will be automatically converted into data container object. \n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "NBXA8a410Cy3"
+      },
+      "source": [
+        "data = Datasets.loadtaskdata(Datasets.datasetpath(\"imagenette2-160\"), ImageClassificationTask)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "YuGkMfNX0NbQ"
+      },
+      "source": [
+        "## Labeling from parent folder names\n",
+        "\n",
+        "To convert data that is already present in the directory and the labels are the name of the parent directory (which is mostly used format in datasets) to data container object, the following code is used,"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "DaORGVg-yft3"
+      },
+      "source": [
+        "using FastAI.Datasets: FileDataset, loadfile, filename\n",
+        "\n",
+        "imagedata = FileDataset(\"/path/to/Dataset\")"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "_w5Sq90x7hoh"
+      },
+      "source": [
+        "`imagedata` consists of all the images in the given folder.\n",
+        " But images aren't associated with their respective classes.\n",
+        " To associate images with their respective classes, we create\n",
+        " a function called `label_func`\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "7h_Cvyhc7pfU",
+        "outputId": "0d56b067-1e60-49e5-d0ac-f5cce860b9d9"
+      },
+      "source": [
+        "function label_func(image)\n",
+        "  return(\n",
+        "    Datasets.loadfile(image),\n",
+        "    filename(parent(image)),\n",
+        "  )\n",
+        "  end"
+      ],
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "label_func (generic function with 1 method)"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 30
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "NCUvP_L_B-AA"
+      },
+      "source": [
+        "Then finally we will map the images with their classes using `mapobs` function"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "gI44C3FiB8N0"
+      },
+      "source": [
+        "image_data_container = mapobs(label_func, imagedata)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "8y_xkkt-DFmo"
+      },
+      "source": [
+        "## Labeling from a CSV file \n",
+        "\n",
+        "If the images are associated with their classses through a CSV file (which is another popular way Datasets are available), then following can be done,"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "-OT4YO0eDEaR"
+      },
+      "source": [
+        "using CSV\n",
+        "using DataFrames\n",
+        "\n",
+        "df = CSV.read(\"example.csv\",DataFrame) # CSV file which consist of that bindings)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "H50AxL16EWI_"
+      },
+      "source": [
+        "Then we need to modify the `label_func`"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "y4WBER0AEa43"
+      },
+      "source": [
+        "function label_func(dataframe)\n",
+        "  return(\n",
+        "    mapobs(Datasets.loadfile(df[!,\"path\"]), df[!,\"class\"]),\n",
+        "  )\n",
+        "  end\n",
+        "\n",
+        "image_data_container = label_func(df)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "tYDG9X4wE_Rz"
+      },
+      "source": [
+        "This version of `label_func` will return the `image_data_container` itself. So no need to call `mapobs`"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "YF9FubrmFiDw"
+      },
+      "source": [
+        "# Learner"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "bdx1u49NFxjj"
+      },
+      "source": [
+        "Learner is the object that binds the data loaders with the model and sets the other hyper parameters like loss function, optimizers, etc. There is `Learner()` function which is similar to fastai's `cnn_learner` function. The below python code can be translated as,\n",
+        "\n",
+        "```\n",
+        "learn = cnn_learner(dls, resnet34, metrics=error_rate)\n",
+        "\n",
+        "#to fine tune\n",
+        "learn.fine_tune(1)\n",
+        "\n",
+        "#to fit one cycle\n",
+        "learn.fit_one_cycle(1)\n",
+        "```"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "xzh7bif3G-HG"
+      },
+      "source": [
+        "model = Models.resnet34(pretrained = true)\n",
+        "metric = Metrics(Metric(Flux.error_rate))\n",
+        "learn = Learner(model, dls, lossfn , metric)\n",
+        "\n",
+        "# to finetune\n",
+        "finetune!(learn, 1)\n",
+        "\n",
+        "# to fit one cycle\n",
+        "fitonecycle!(learn,1)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "fHifey18IVqf"
+      },
+      "source": [
+        "However, `Learn` method makes us to define every parameters manually. Like we should explicitly convert our data container object to `dataloader` object and pass them. \n",
+        "\n",
+        "Instead we can cut the complexity by using `methodlearner` function where everything can be passed as hyperparameters. The cool thing about `methodlearner` is it takes the data container object and implicitly converts it into dataloader, where the batch size, validation split can be customized if we need. Therefore the above code can be converted into, "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "1_hrwdCGIVFG"
+      },
+      "source": [
+        "method = ImageClassification(classnames , image_size)\n",
+        "learn = methodlearner(method, image_data_container, Models.resnet34(pretrained = true))\n",
+        "\n",
+        "# to finetune\n",
+        "finetune!(learn, 1)\n",
+        "\n",
+        "# to fit one cycle\n",
+        "fitonecycle!(learn,1)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "04tgsb-GL3eM"
+      },
+      "source": [
+        "wehre `classnames` is a vector consists of names of classes in whole dataset and `image_size` is a tuple with length and breadth of images."
+      ]
+    }
+  ]
+}

--- a/docs/notebooks/Migration_Guide_beginner.ipynb
+++ b/docs/notebooks/Migration_Guide_beginner.ipynb
@@ -190,7 +190,7 @@
         "id": "fFmwN26ZA5wO"
       },
       "source": [
-        "Dataloaders are important aspects of fastai's python library. These objects are like assembly lines that feed materials to the machine. Likewise dataloaders feed data to the model. \n",
+        "Dataloaders are important aspects of fastai's python library. Like an assembly line feeding materials to the next machine, dataloaders feed data to the model. \n",
         "\n",
         "Though there is dataloader object in FastAI.jl, we can skip the complexity of creating separate training and validation dataloaders by using data container object and using ```methodlearner()``` function (more below)\n",
         "\n",

--- a/docs/notebooks/Migration_Guide_beginner.ipynb
+++ b/docs/notebooks/Migration_Guide_beginner.ipynb
@@ -1,25 +1,4 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "accelerator": "GPU",
-    "colab": {
-      "name": "Migration_Guide_beginner.ipynb",
-      "provenance": [],
-      "collapsed_sections": [],
-      "toc_visible": true
-    },
-    "kernelspec": {
-      "display_name": "Julia",
-      "language": "julia",
-      "name": "julia"
-    },
-    "language_info": {
-      "file_extension": ".jl",
-      "mimetype": "application/julia",
-      "name": "julia"
-    }
-  },
   "cells": [
     {
       "cell_type": "markdown",
@@ -34,15 +13,15 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "22CaKZYa6cwN"
       },
+      "outputs": [],
       "source": [
         "using FastAI\n",
         "using FastAI.Datasets"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -64,20 +43,17 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "2HYP1rzuOpR5",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
+        "id": "2HYP1rzuOpR5",
         "outputId": "b221de78-a3bc-4d16-90fb-e68ceb223740"
       },
-      "source": [
-        "# Julia Code\n",
-        "data = Datasets.loadtaskdata(Datasets.datasetpath(\"imagenette2-160\"), ImageClassificationTask)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "This program has requested access to the data dependency fastai-imagenette2-160.\n",
@@ -94,10 +70,10 @@
             "Do you want to download the dataset from https://s3.amazonaws.com/fast-ai-imageclas/imagenette2-160.tgz to \"/root/.julia/datadeps/fastai-imagenette2-160\"?\n",
             "[y/n]\n",
             "stdin> y\n"
-          ],
-          "name": "stdout"
+          ]
         },
         {
+          "name": "stderr",
           "output_type": "stream",
           "text": [
             "┌ Info: Downloading\n",
@@ -111,10 +87,10 @@
             "│   remaining = 0 bytes\n",
             "│   total = 94.417 MiB\n",
             "└ @ HTTP /root/.julia/packages/HTTP/cxgat/src/download.jl:119\n"
-          ],
-          "name": "stderr"
+          ]
         },
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "\n",
@@ -134,22 +110,25 @@
             "Files: 13397\n",
             "Size:       107794109\n",
             "Compressed: 6872064\n"
-          ],
-          "name": "stdout"
+          ]
         },
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "mapobs((input = FastAI.Datasets.loadfile, target = FastAI.Datasets.var\"#27#32\"()), DataSubset(::FileDataset, ::Vector{Int64}, ObsDim.Undefined())\n",
               " 13394 observations)"
             ]
           },
+          "execution_count": 9,
           "metadata": {
             "tags": []
           },
-          "execution_count": 9
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Julia Code\n",
+        "data = Datasets.loadtaskdata(Datasets.datasetpath(\"imagenette2-160\"), ImageClassificationTask)"
       ]
     },
     {
@@ -190,25 +169,29 @@
         "id": "fFmwN26ZA5wO"
       },
       "source": [
-        "Dataloaders are important aspects of fastai's python library. Like an assembly line feeding materials to the next machine, dataloaders feed data to the model. \n",
-        "\n",
-        "Though there is dataloader object in FastAI.jl, we can skip the complexity of creating separate training and validation dataloaders by using data container object and using ```methodlearner()``` function (more below)\n",
-        "\n",
-        "## To convert fastai datasets\n",
-        "\n",
-        "As dicussed above fastai datasets downloaded using ```loadtaskdata()``` function will be automatically converted into data container object. \n"
+        "Dataloaders are important aspects of fastai's python library. Like an assembly line feeding materials to the next machine, dataloaders feed data to the model. \r\n",
+        "\r\n",
+        "Though there is dataloader object in FastAI.jl, we can skip the complexity of creating separate training and validation dataloaders by using data container object and using ```methodlearner()``` function (more below)\r\n",
+        "\r\n",
+        "Yet, data container and dataloaders aren't same in FastAI.jl. As the name suggests `data container` is a **container**. It saves the individual elements of dataset in an array-like format. `dataloader` on the other hand is an **iterator**. It is an object that's built on top of container and used to traverse the container i.e., taking only few elements at a time (a batch) from the data container, while maintaining the record of indices of the batch. \r\n",
+        "\r\n",
+        "Here's the cool stuff about FastAI.jl. In fastai's python library, container and iterator objects are separate entities. They have nothing in common. But here, they share a similar interface. To get nth element (probably a tuple of an image and its class) from either a data container or dataloader, ```getobs(x, n)``` where x can be either a data container or dataloader. Similarly to get number of elements in an data container or dataloader, we can use ```nobs(X)``` where x is a data container or dataloader. \r\n",
+        "\r\n",
+        "## To convert fastai datasets\r\n",
+        "\r\n",
+        "As dicussed above fastai datasets downloaded using ```loadtaskdata()``` function will be automatically converted into data container object. \r\n"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "NBXA8a410Cy3"
       },
+      "outputs": [],
       "source": [
         "data = Datasets.loadtaskdata(Datasets.datasetpath(\"imagenette2-160\"), ImageClassificationTask)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -223,16 +206,16 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "DaORGVg-yft3"
       },
+      "outputs": [],
       "source": [
         "using FastAI.Datasets: FileDataset, loadfile, filename\n",
         "\n",
         "imagedata = FileDataset(\"/path/to/Dataset\")"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -248,6 +231,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -255,6 +239,20 @@
         "id": "7h_Cvyhc7pfU",
         "outputId": "0d56b067-1e60-49e5-d0ac-f5cce860b9d9"
       },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "label_func (generic function with 1 method)"
+            ]
+          },
+          "execution_count": 30,
+          "metadata": {
+            "tags": []
+          },
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "function label_func(image)\n",
         "  return(\n",
@@ -262,21 +260,6 @@
         "    filename(parent(image)),\n",
         "  )\n",
         "  end"
-      ],
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "label_func (generic function with 1 method)"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "execution_count": 30
-        }
       ]
     },
     {
@@ -290,14 +273,14 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "gI44C3FiB8N0"
       },
+      "outputs": [],
       "source": [
         "image_data_container = mapobs(label_func, imagedata)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -312,17 +295,17 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "-OT4YO0eDEaR"
       },
+      "outputs": [],
       "source": [
         "using CSV\n",
         "using DataFrames\n",
         "\n",
         "df = CSV.read(\"example.csv\",DataFrame) # CSV file which consist of that bindings)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -335,9 +318,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "y4WBER0AEa43"
       },
+      "outputs": [],
       "source": [
         "function label_func(dataframe)\n",
         "  return(\n",
@@ -346,9 +331,7 @@
         "  end\n",
         "\n",
         "image_data_container = label_func(df)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -389,39 +372,11 @@
     },
     {
       "cell_type": "code",
-      "metadata": {
-        "id": "xzh7bif3G-HG"
-      },
-      "source": [
-        "model = Models.resnet34(pretrained = true)\n",
-        "metric = Metrics(Metric(Flux.error_rate))\n",
-        "learn = Learner(model, dls, lossfn , metric)\n",
-        "\n",
-        "# to finetune\n",
-        "finetune!(learn, 1)\n",
-        "\n",
-        "# to fit one cycle\n",
-        "fitonecycle!(learn,1)"
-      ],
       "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "fHifey18IVqf"
-      },
-      "source": [
-        "However, `Learn` method makes us to define every parameters manually. Like we should explicitly convert our data container object to `dataloader` object and pass them. \n",
-        "\n",
-        "Instead we can cut the complexity by using `methodlearner` function where everything can be passed as hyperparameters. The cool thing about `methodlearner` is it takes the data container object and implicitly converts it into dataloader, where the batch size, validation split can be customized if we need. Therefore the above code can be converted into, "
-      ]
-    },
-    {
-      "cell_type": "code",
       "metadata": {
         "id": "1_hrwdCGIVFG"
       },
+      "outputs": [],
       "source": [
         "method = ImageClassification(classnames , image_size)\n",
         "learn = methodlearner(method, image_data_container, Models.resnet34(pretrained = true))\n",
@@ -431,9 +386,7 @@
         "\n",
         "# to fit one cycle\n",
         "fitonecycle!(learn, 1)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -444,5 +397,26 @@
         "where `classnames` is a vector consists of names of classes in whole dataset and `image_size` is a tuple with length and breadth of images."
       ]
     }
-  ]
+  ],
+  "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "collapsed_sections": [],
+      "name": "Migration_Guide_beginner.ipynb",
+      "provenance": [],
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Julia",
+      "language": "julia",
+      "name": "julia"
+    },
+    "language_info": {
+      "file_extension": ".jl",
+      "mimetype": "application/julia",
+      "name": "julia"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }


### PR DESCRIPTION
First of three part tutorial on migrating from Fastai's python library to FastAI.jl. This is supposed to beginner level and I've written down things that I felt crucial when I came from the Fastai's python's library.