### PR TITLE
update get_emb_sz method

### DIFF
--- a/notebooks/tabularclassification.ipynb
+++ b/notebooks/tabularclassification.ipynb
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "bc1f44bd",
    "metadata": {},
    "outputs": [],
@@ -41,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "bc82faca",
    "metadata": {},
    "outputs": [
@@ -77,7 +77,7 @@
        "\u001b[36m                                               10 columns and 32540 rows omitted\u001b[0m)"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -115,7 +115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "3d4b1c5f",
    "metadata": {},
    "outputs": [],
@@ -139,7 +139,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "id": "dc67d139",
    "metadata": {},
    "outputs": [],
@@ -152,7 +152,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "id": "574fb149",
    "metadata": {},
    "outputs": [
@@ -161,7 +161,7 @@
      "output_type": "stream",
      "text": [
       "┌ Warning: There is a missing value present for category 'occupation' which will be removed from Categorify dict\n",
-      "└ @ DataAugmentation /home/lorenz/.julia/dev/DataAugmentation/src/rowtransforms.jl:108\n"
+      "└ @ DataAugmentation /Users/manikyabardhan/.julia/packages/DataAugmentation/IwnxZ/src/rowtransforms.jl:108\n"
      ]
     },
     {
@@ -170,7 +170,7 @@
        "BlockMethod(TableRow{8, 6, Dict{Any, Any}} -> Label{String})"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -220,7 +220,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "id": "2630c9d1",
    "metadata": {},
    "outputs": [
@@ -245,13 +245,13 @@
        "\\texttt{TabularPreprocessing} &  & \\textbf{\\texttt{FastAI.EncodedTableRow\\{8, 6, Dict\\{Any, Any\\}\\}}} & \\texttt{Label\\{String\\}} \\\\\n",
        "\\texttt{OneHot} & \\texttt{(x, y)} & \\texttt{FastAI.EncodedTableRow\\{8, 6, Dict\\{Any, Any\\}\\}} & \\textbf{\\texttt{FastAI.OneHotTensor\\{0, String\\}}} \\\\\n",
        "\\end{tabular}\n",
-       "Decoding a model output (\\texttt{decode(method, context, ŷ)})\n",
+       "Decoding a model output (\\texttt{decode(method, context, ŷ)})\n",
        "\n",
        "\\begin{tabular}\n",
        "{r | r | r}\n",
        "Decoding & Name & \\texttt{method.outputblock} \\\\\n",
        "\\hline\n",
-       " & \\texttt{ŷ} & \\texttt{FastAI.OneHotTensor\\{0, String\\}} \\\\\n",
+       " & \\texttt{ŷ} & \\texttt{FastAI.OneHotTensor\\{0, String\\}} \\\\\n",
        "\\texttt{OneHot} &  & \\textbf{\\texttt{Label\\{String\\}}} \\\\\n",
        "\\texttt{TabularPreprocessing} & \\texttt{target\\_pred} & \\texttt{Label\\{String\\}} \\\\\n",
        "\\end{tabular}\n"
@@ -270,11 +270,11 @@
        "| `TabularPreprocessing` |                   | **`FastAI.EncodedTableRow{8, 6, Dict{Any, Any}}`** |                      `Label{String}` |\n",
        "|               `OneHot` |          `(x, y)` |     `FastAI.EncodedTableRow{8, 6, Dict{Any, Any}}` | **`FastAI.OneHotTensor{0, String}`** |\n",
        "\n",
-       "Decoding a model output (`decode(method, context, ŷ)`)\n",
+       "Decoding a model output (`decode(method, context, ŷ)`)\n",
        "\n",
        "|               Decoding |          Name |             `method.outputblock` |\n",
        "| ----------------------:| -------------:| --------------------------------:|\n",
-       "|                        |          `ŷ` | `FastAI.OneHotTensor{0, String}` |\n",
+       "|                        |          `ŷ` | `FastAI.OneHotTensor{0, String}` |\n",
        "|               `OneHot` |               |              **`Label{String}`** |\n",
        "| `TabularPreprocessing` | `target_pred` |                  `Label{String}` |\n"
       ],
@@ -295,16 +295,16 @@
        "  \u001b[36mTabularPreprocessing\u001b[39m                 \u001b[1m\u001b[36mFastAI.EncodedTableRow{8, 6, Dict{Any, Any}}\u001b[39m\u001b[22m                  \u001b[36mLabel{String}\u001b[39m\n",
        "                \u001b[36mOneHot\u001b[39m          \u001b[36m(x, y)\u001b[39m \u001b[36mFastAI.EncodedTableRow{8, 6, Dict{Any, Any}}\u001b[39m \u001b[1m\u001b[36mFastAI.OneHotTensor{0, String}\u001b[39m\u001b[22m\n",
        "\n",
-       "  Decoding a model output (\u001b[36mdecode(method, context, ŷ)\u001b[39m)\n",
+       "  Decoding a model output (\u001b[36mdecode(method, context, ŷ)\u001b[39m)\n",
        "\n",
        "              Decoding        Name             \u001b[36mmethod.outputblock\u001b[39m\n",
        "  –––––––––––––––––––– ––––––––––– ––––––––––––––––––––––––––––––\n",
-       "                                \u001b[36mŷ\u001b[39m \u001b[36mFastAI.OneHotTensor{0, String}\u001b[39m\n",
+       "                                \u001b[36mŷ\u001b[39m \u001b[36mFastAI.OneHotTensor{0, String}\u001b[39m\n",
        "                \u001b[36mOneHot\u001b[39m                              \u001b[1m\u001b[36mLabel{String}\u001b[39m\u001b[22m\n",
        "  \u001b[36mTabularPreprocessing\u001b[39m \u001b[36mtarget_pred\u001b[39m                  \u001b[36mLabel{String}\u001b[39m"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -323,7 +323,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
    "id": "e306b703-e47e-450e-83e7-34ff1aae86b4",
    "metadata": {},
    "outputs": [
@@ -338,7 +338,7 @@
        "\u001b[36m                                                              10 columns omitted\u001b[0m, \"<50k\")"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -349,7 +349,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 8,
    "id": "924c717f",
    "metadata": {},
    "outputs": [
@@ -359,7 +359,7 @@
        "(([5, 16, 2, 10, 5, 2, 3, 2], [1.6435221651965317, -0.2567538819371021, -2.751580937680526, -0.14591824281680102, -0.21665620002803673, -0.035428902921319616]), Float32[0.0, 1.0])"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -378,7 +378,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 9,
    "id": "9bdff3ae",
    "metadata": {},
    "outputs": [
@@ -389,17 +389,17 @@
        "  Parallel(\n",
        "    vcat,\n",
        "    Chain(\n",
-       "      FastAI.Models.var\"#43#45\"(),\n",
+       "      FastAI.Models.var\"#41#43\"(),\n",
        "      Parallel(\n",
        "        vcat,\n",
-       "        Embedding(17, 8),               \u001b[90m# 136 parameters\u001b[39m\n",
-       "        Embedding(6, 4),                \u001b[90m# 24 parameters\u001b[39m\n",
-       "        Embedding(3, 3),                \u001b[90m# 9 parameters\u001b[39m\n",
        "        Embedding(10, 6),               \u001b[90m# 60 parameters\u001b[39m\n",
        "        Embedding(17, 8),               \u001b[90m# 136 parameters\u001b[39m\n",
-       "        Embedding(7, 5),                \u001b[90m# 35 parameters\u001b[39m\n",
-       "        Embedding(43, 13),              \u001b[90m# 559 parameters\u001b[39m\n",
        "        Embedding(8, 5),                \u001b[90m# 40 parameters\u001b[39m\n",
+       "        Embedding(17, 8),               \u001b[90m# 136 parameters\u001b[39m\n",
+       "        Embedding(7, 5),                \u001b[90m# 35 parameters\u001b[39m\n",
+       "        Embedding(6, 4),                \u001b[90m# 24 parameters\u001b[39m\n",
+       "        Embedding(3, 3),                \u001b[90m# 9 parameters\u001b[39m\n",
+       "        Embedding(43, 13),              \u001b[90m# 559 parameters\u001b[39m\n",
        "      ),\n",
        "      identity,\n",
        "    ),\n",
@@ -415,11 +415,11 @@
        "    BatchNorm(100),                     \u001b[90m# 200 parameters\u001b[39m\u001b[90m, plus 200\u001b[39m\n",
        "    identity,\n",
        "  ),\n",
-       "  2,\n",
-       ")\u001b[90m                   # Total: 16 arrays, \u001b[39m33_211 parameters, 129.273 KiB."
+       "  Dense(100, 2),                        \u001b[90m# 202 parameters\u001b[39m\n",
+       ")\u001b[90m                   # Total: 18 arrays, \u001b[39m33_413 parameters, 130.172 KiB."
       ]
      },
-     "execution_count": 11,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -438,13 +438,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 10,
    "id": "895aa501",
    "metadata": {},
    "outputs": [],
    "source": [
     "cardinalities = collect(map(col -> length(catdict[col]), cat))\n",
-    "embedszs = FastAI.Models.get_emb_sz(cardinalities)\n",
+    "\n",
+    "ovdict = Dict(:workclass => 10, :education => 12, Symbol(\"native-country\") => 16)\n",
+    "overrides = collect(map(col -> col in keys(ovdict) ? ovdict[col] : nothing, cat))\n",
+    "\n",
+    "embedszs = FastAI.Models.get_emb_sz(cardinalities, overrides)\n",
     "catback = FastAI.Models.tabular_embedding_backbone(embedszs, 0.2);"
    ]
   },
@@ -458,7 +462,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 11,
    "id": "36dc2f05",
    "metadata": {},
    "outputs": [
@@ -469,24 +473,24 @@
        "  Parallel(\n",
        "    vcat,\n",
        "    Chain(\n",
-       "      FastAI.Models.var\"#43#45\"(),\n",
+       "      FastAI.Models.var\"#41#43\"(),\n",
        "      Parallel(\n",
        "        vcat,\n",
-       "        Embedding(10, 6),               \u001b[90m# 60 parameters\u001b[39m\n",
-       "        Embedding(17, 8),               \u001b[90m# 136 parameters\u001b[39m\n",
+       "        Embedding(10, 10),              \u001b[90m# 100 parameters\u001b[39m\n",
+       "        Embedding(17, 12),              \u001b[90m# 204 parameters\u001b[39m\n",
        "        Embedding(8, 5),                \u001b[90m# 40 parameters\u001b[39m\n",
        "        Embedding(17, 8),               \u001b[90m# 136 parameters\u001b[39m\n",
        "        Embedding(7, 5),                \u001b[90m# 35 parameters\u001b[39m\n",
        "        Embedding(6, 4),                \u001b[90m# 24 parameters\u001b[39m\n",
        "        Embedding(3, 3),                \u001b[90m# 9 parameters\u001b[39m\n",
-       "        Embedding(43, 13),              \u001b[90m# 559 parameters\u001b[39m\n",
+       "        Embedding(43, 16),              \u001b[90m# 688 parameters\u001b[39m\n",
        "      ),\n",
        "      Dropout(0.2),\n",
        "    ),\n",
        "    BatchNorm(6),                       \u001b[90m# 12 parameters\u001b[39m\u001b[90m, plus 12\u001b[39m\n",
        "  ),\n",
        "  Chain(\n",
-       "    Dense(58, 200, relu; bias=false),   \u001b[90m# 11_600 parameters\u001b[39m\n",
+       "    Dense(69, 200, relu; bias=false),   \u001b[90m# 13_800 parameters\u001b[39m\n",
        "    BatchNorm(200),                     \u001b[90m# 400 parameters\u001b[39m\u001b[90m, plus 400\u001b[39m\n",
        "    identity,\n",
        "  ),\n",
@@ -496,10 +500,10 @@
        "    identity,\n",
        "  ),\n",
        "  Dense(100, 2),                        \u001b[90m# 202 parameters\u001b[39m\n",
-       ")\u001b[90m                   # Total: 18 arrays, \u001b[39m33_413 parameters, 130.234 KiB."
+       ")\u001b[90m                   # Total: 18 arrays, \u001b[39m35_850 parameters, 138.828 KiB."
       ]
      },
-     "execution_count": 30,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -519,7 +523,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 12,
    "id": "64c2b78e",
    "metadata": {},
    "outputs": [
@@ -529,7 +533,7 @@
        "Learner()"
       ]
      },
-     "execution_count": 49,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -550,7 +554,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 13,
    "id": "6d67b11e",
    "metadata": {},
    "outputs": [
@@ -558,7 +562,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32mEpoch 1 TrainingPhase(): 100%|██████████████████████████| Time: 0:00:02\u001b[39m\n"
+      "\u001b[32mEpoch 1 TrainingPhase(): 100%|██████████████████████████| Time: 0:00:57\u001b[39m\n"
      ]
     },
     {
@@ -568,7 +572,7 @@
       "┌───────────────┬───────┬─────────┬──────────┐\n",
       "│\u001b[1m         Phase \u001b[0m│\u001b[1m Epoch \u001b[0m│\u001b[1m    Loss \u001b[0m│\u001b[1m Accuracy \u001b[0m│\n",
       "├───────────────┼───────┼─────────┼──────────┤\n",
-      "│ TrainingPhase │   1.0 │ 0.44043 │  0.82431 │\n",
+      "│ TrainingPhase │   1.0 │ 0.38906 │  0.81998 │\n",
       "└───────────────┴───────┴─────────┴──────────┘\n"
      ]
     },
@@ -576,7 +580,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32mEpoch 1 ValidationPhase(): 100%|████████████████████████| Time: 0:00:00\u001b[39m\n"
+      "\u001b[32mEpoch 1 ValidationPhase(): 100%|████████████████████████| Time: 0:00:02\u001b[39m\n"
      ]
     },
     {
@@ -586,7 +590,7 @@
       "┌─────────────────┬───────┬─────────┬──────────┐\n",
       "│\u001b[1m           Phase \u001b[0m│\u001b[1m Epoch \u001b[0m│\u001b[1m    Loss \u001b[0m│\u001b[1m Accuracy \u001b[0m│\n",
       "├─────────────────┼───────┼─────────┼──────────┤\n",
-      "│ ValidationPhase │   1.0 │ 0.39627 │  0.81209 │\n",
+      "│ ValidationPhase │   1.0 │ 0.33287 │  0.84165 │\n",
       "└─────────────────┴───────┴─────────┴──────────┘\n"
      ]
     },
@@ -594,7 +598,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32mEpoch 2 TrainingPhase(): 100%|██████████████████████████| Time: 0:00:02\u001b[39m\n"
+      "\u001b[32mEpoch 2 TrainingPhase(): 100%|██████████████████████████| Time: 0:00:03\u001b[39m\n"
      ]
     },
     {
@@ -604,7 +608,7 @@
       "┌───────────────┬───────┬─────────┬──────────┐\n",
       "│\u001b[1m         Phase \u001b[0m│\u001b[1m Epoch \u001b[0m│\u001b[1m    Loss \u001b[0m│\u001b[1m Accuracy \u001b[0m│\n",
       "├───────────────┼───────┼─────────┼──────────┤\n",
-      "│ TrainingPhase │   2.0 │ 0.34174 │  0.84043 │\n",
+      "│ TrainingPhase │   2.0 │ 0.35171 │  0.83392 │\n",
       "└───────────────┴───────┴─────────┴──────────┘\n"
      ]
     },
@@ -622,7 +626,7 @@
       "┌─────────────────┬───────┬─────────┬──────────┐\n",
       "│\u001b[1m           Phase \u001b[0m│\u001b[1m Epoch \u001b[0m│\u001b[1m    Loss \u001b[0m│\u001b[1m Accuracy \u001b[0m│\n",
       "├─────────────────┼───────┼─────────┼──────────┤\n",
-      "│ ValidationPhase │   2.0 │ 0.31593 │  0.85412 │\n",
+      "│ ValidationPhase │   2.0 │ 0.31995 │   0.8554 │\n",
       "└─────────────────┴───────┴─────────┴──────────┘\n"
      ]
     },
@@ -630,7 +634,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32mEpoch 3 TrainingPhase(): 100%|██████████████████████████| Time: 0:00:02\u001b[39m\n"
+      "\u001b[32mEpoch 3 TrainingPhase(): 100%|██████████████████████████| Time: 0:00:04\u001b[39m\n"
      ]
     },
     {
@@ -640,7 +644,7 @@
       "┌───────────────┬───────┬─────────┬──────────┐\n",
       "│\u001b[1m         Phase \u001b[0m│\u001b[1m Epoch \u001b[0m│\u001b[1m    Loss \u001b[0m│\u001b[1m Accuracy \u001b[0m│\n",
       "├───────────────┼───────┼─────────┼──────────┤\n",
-      "│ TrainingPhase │   3.0 │ 0.31959 │  0.85215 │\n",
+      "│ TrainingPhase │   3.0 │ 0.32234 │  0.84912 │\n",
       "└───────────────┴───────┴─────────┴──────────┘\n"
      ]
     },
@@ -658,7 +662,7 @@
       "┌─────────────────┬───────┬─────────┬──────────┐\n",
       "│\u001b[1m           Phase \u001b[0m│\u001b[1m Epoch \u001b[0m│\u001b[1m    Loss \u001b[0m│\u001b[1m Accuracy \u001b[0m│\n",
       "├─────────────────┼───────┼─────────┼──────────┤\n",
-      "│ ValidationPhase │   3.0 │ 0.31082 │  0.85588 │\n",
+      "│ ValidationPhase │   3.0 │ 0.30943 │  0.85641 │\n",
       "└─────────────────┴───────┴─────────┴──────────┘\n"
      ]
     }
@@ -666,19 +670,27 @@
    "source": [
     "fitonecycle!(learner, 3, 0.2)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6d5d9972-2e1c-4cf1-a8da-8750f9de041e",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia (12 threads) 1.6.2",
+   "display_name": "Julia 1.6.1",
    "language": "julia",
-   "name": "julia-(12-threads)-1.6"
+   "name": "julia-1.6"
   },
   "language_info": {
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "1.6.2"
+   "version": "1.6.1"
   }
  },
  "nbformat": 4,

--- a/src/datablock/models.jl
+++ b/src/datablock/models.jl
@@ -115,7 +115,7 @@ blockbackbone(inblock::ImageTensor{2}) = Models.xresnet18(c_in = inblock.nchanne
 
 
 function blockbackbone(inblock::EncodedTableRow{M, N}) where {M, N}
-    embedszs = Models.get_emb_sz(Dict((col => length(inblock.categorydict[col]) for col in inblock.catcols)))
+    embedszs = Models.get_emb_sz(Dict((col => length(inblock.categorydict[col]) for col in inblock.catcols)), inblock.catcols)
     catback = Models.tabular_embedding_backbone(embedszs)
     contback = Models.tabular_continuous_backbone(N)
     return (categorical = catback, continuous = contback)

--- a/src/datablock/models.jl
+++ b/src/datablock/models.jl
@@ -115,7 +115,7 @@ blockbackbone(inblock::ImageTensor{2}) = Models.xresnet18(c_in = inblock.nchanne
 
 
 function blockbackbone(inblock::EncodedTableRow{M, N}) where {M, N}
-    embedszs = Models.get_emb_sz(Dict((col => length(inblock.categorydict[col]) for col in inblock.catcols)), inblock.catcols)
+    embedszs = Models.get_emb_sz(collect(map(col->length(inblock.categorydict[col]), inblock.catcols)))
     catback = Models.tabular_embedding_backbone(embedszs)
     contback = Models.tabular_continuous_backbone(N)
     return (categorical = catback, continuous = contback)

--- a/src/models/tabularmodel.jl
+++ b/src/models/tabularmodel.jl
@@ -27,9 +27,9 @@ get_emb_sz(cardinalities::AbstractVector{<:Integer}, size_overrides=fill(nothing
     end
 
 """
-    get_emb_sz(cardinalities::Dict, [size_overrides::Dict])
+    get_emb_sz(cardinalities::Dict, cols, [size_overrides::Dict])
 
-Given a map from columns to `cardinalities`, compute the output embedding size according to [`emb_sz_rule`](#).
+Given a map from columns to `cardinalities` and a collection `cols` of columns, compute the output embedding size according to [`emb_sz_rule`](#).
 Return a vector of tuples where each element is `(in_size, out_size)` for an embedding layer.
 
 ## Keyword arguments
@@ -37,9 +37,9 @@ Return a vector of tuples where each element is `(in_size, out_size)` for an emb
 - `size_overrides`: A map of output embedding size overrides
                     (i.e. `size_overrides[col]` is the output embedding size for `col`).
 """
-function get_emb_sz(cardinalities::Dict{<:Any, <:Integer}, size_overrides=Dict())
-    values_and_overrides = map(collect(pairs(cardinalities))) do (col, cardinality)
-        cardinality, get(size_overrides, col, nothing)
+function get_emb_sz(cardinalities::Dict{<:Any, <:Integer}, cols, size_overrides=Dict())
+    values_and_overrides = map(collect(cols)) do col
+        cardinalities[col], get(size_overrides, col, nothing)
     end
     get_emb_sz(first.(values_and_overrides), last.(values_and_overrides))
 end

--- a/src/models/tabularmodel.jl
+++ b/src/models/tabularmodel.jl
@@ -26,24 +26,6 @@ get_emb_sz(cardinalities::AbstractVector{<:Integer}, size_overrides=fill(nothing
         return (cardinality + 1, emb_dim)
     end
 
-"""
-    get_emb_sz(cardinalities::Dict, cols, [size_overrides::Dict])
-
-Given a map from columns to `cardinalities` and a collection `cols` of columns, compute the output embedding size according to [`emb_sz_rule`](#).
-Return a vector of tuples where each element is `(in_size, out_size)` for an embedding layer.
-
-## Keyword arguments
-
-- `size_overrides`: A map of output embedding size overrides
-                    (i.e. `size_overrides[col]` is the output embedding size for `col`).
-"""
-function get_emb_sz(cardinalities::Dict{<:Any, <:Integer}, cols, size_overrides=Dict())
-    values_and_overrides = map(collect(cols)) do col
-        cardinalities[col], get(size_overrides, col, nothing)
-    end
-    get_emb_sz(first.(values_and_overrides), last.(values_and_overrides))
-end
-
 sigmoidrange(x, low, high) = @. Flux.sigmoid(x) * (high - low) + low
 
 function tabular_embedding_backbone(embedding_sizes, dropout_rate=0.)


### PR DESCRIPTION
Updates `get_emb_sz` to ensure the order of embedding sizes is as expected which might not have been the case with just using `Dict` key order.