### PR TITLE
Setup step for encodings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] - 2020-07-32 – now
 
 ### Added
+
 - High-level API "FasterAI"
+    - dataset recipes
+    - learning method helpers
     - Find datasets and learning methods based on `Block`s: `finddataset`, `findlearningmethods`
     - `loaddataset` for quickly loading data containers from configured recipes
 - Data container recipes (`DatasetRecipe`, `loadrecipe`)
@@ -16,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - [Blocks and encodings](https://fluxml.ai/FastAI.jl/dev/docs/background/blocksencodings.md.html)
 - New interfaces
     - `blockbackbone` creates a default backbone for an input block
+- Support for tabular data along with recipes and learning methods:
+    - [`TabularPreprocessing`], [`TableRow`], [`TableDataset`], [`TabularClassificiationSingle`], [`TabularRegression`]
+    - [Tabular classification tutorial](https://fluxml.ai/FastAI.jl/dev/notebooks/tabularclassification.ipynb.html)
 
 
 ### Changed

--- a/notebooks/quickstart.ipynb
+++ b/notebooks/quickstart.ipynb
@@ -31,7 +31,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -651,6 +651,130 @@
    ],
    "source": [
     "plotpredictions(method, learner)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Tabular data "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Classification "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "┌ Warning: There is a missing value present for category 'occupation' which will be removed from Categorify dict\n",
+      "└ @ DataAugmentation /home/lorenz/.julia/dev/DataAugmentation/src/rowtransforms.jl:108\n",
+      "\u001b[32mEpoch 1 TrainingPhase(): 100%|██████████████████████████| Time: 0:00:03\u001b[39m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "┌───────────────┬───────┬─────────┬──────────┐\n",
+      "│\u001b[1m         Phase \u001b[0m│\u001b[1m Epoch \u001b[0m│\u001b[1m    Loss \u001b[0m│\u001b[1m Accuracy \u001b[0m│\n",
+      "├───────────────┼───────┼─────────┼──────────┤\n",
+      "│ TrainingPhase │   1.0 │ 0.38761 │  0.82087 │\n",
+      "└───────────────┴───────┴─────────┴──────────┘\n",
+      "┌─────────────────┬───────┬─────────┬──────────┐\n",
+      "│\u001b[1m           Phase \u001b[0m│\u001b[1m Epoch \u001b[0m│\u001b[1m    Loss \u001b[0m│\u001b[1m Accuracy \u001b[0m│\n",
+      "├─────────────────┼───────┼─────────┼──────────┤\n",
+      "│ ValidationPhase │   1.0 │ 0.35193 │  0.82596 │\n",
+      "└─────────────────┴───────┴─────────┴──────────┘\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32mEpoch 2 TrainingPhase(): 100%|██████████████████████████| Time: 0:00:03\u001b[39m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "┌───────────────┬───────┬─────────┬──────────┐\n",
+      "│\u001b[1m         Phase \u001b[0m│\u001b[1m Epoch \u001b[0m│\u001b[1m    Loss \u001b[0m│\u001b[1m Accuracy \u001b[0m│\n",
+      "├───────────────┼───────┼─────────┼──────────┤\n",
+      "│ TrainingPhase │   2.0 │ 0.33952 │  0.84105 │\n",
+      "└───────────────┴───────┴─────────┴──────────┘\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32mEpoch 2 ValidationPhase(): 100%|████████████████████████| Time: 0:00:00\u001b[39m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "┌─────────────────┬───────┬─────────┬──────────┐\n",
+      "│\u001b[1m           Phase \u001b[0m│\u001b[1m Epoch \u001b[0m│\u001b[1m    Loss \u001b[0m│\u001b[1m Accuracy \u001b[0m│\n",
+      "├─────────────────┼───────┼─────────┼──────────┤\n",
+      "│ ValidationPhase │   2.0 │ 0.32707 │  0.84658 │\n",
+      "└─────────────────┴───────┴─────────┴──────────┘\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32mEpoch 3 TrainingPhase(): 100%|██████████████████████████| Time: 0:00:03\u001b[39m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "┌───────────────┬───────┬────────┬──────────┐\n",
+      "│\u001b[1m         Phase \u001b[0m│\u001b[1m Epoch \u001b[0m│\u001b[1m   Loss \u001b[0m│\u001b[1m Accuracy \u001b[0m│\n",
+      "├───────────────┼───────┼────────┼──────────┤\n",
+      "│ TrainingPhase │   3.0 │ 0.3228 │  0.84898 │\n",
+      "└───────────────┴───────┴────────┴──────────┘\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32mEpoch 3 ValidationPhase(): 100%|████████████████████████| Time: 0:00:00\u001b[39m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "┌─────────────────┬───────┬─────────┬──────────┐\n",
+      "│\u001b[1m           Phase \u001b[0m│\u001b[1m Epoch \u001b[0m│\u001b[1m    Loss \u001b[0m│\u001b[1m Accuracy \u001b[0m│\n",
+      "├─────────────────┼───────┼─────────┼──────────┤\n",
+      "│ ValidationPhase │   3.0 │ 0.32043 │  0.84688 │\n",
+      "└─────────────────┴───────┴─────────┴──────────┘\n"
+     ]
+    }
+   ],
+   "source": [
+    "data, blocks = loaddataset(\"adult_sample\", (TableRow, Label))\n",
+    "method = TabularClassificationSingle(blocks, data)\n",
+    "learner = methodlearner(method, data; callbacks=[Metrics(accuracy)], batchsize=128)\n",
+    "fitonecycle!(learner, 3, 0.2)"
    ]
   }
  ],

--- a/notebooks/tabularclassification.ipynb
+++ b/notebooks/tabularclassification.ipynb
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 12,
    "id": "bc1f44bd",
    "metadata": {},
    "outputs": [],
@@ -28,7 +28,7 @@
     "using Tables\n",
     "using Statistics\n",
     "using FluxTraining\n",
-    "using DataAugmentation"
+    "import DataAugmentation"
    ]
   },
   {
@@ -41,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 5,
    "id": "bc82faca",
    "metadata": {},
    "outputs": [
@@ -77,7 +77,7 @@
        "\u001b[36m                                               10 columns and 32540 rows omitted\u001b[0m)"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -115,7 +115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 6,
    "id": "3d4b1c5f",
    "metadata": {},
    "outputs": [],
@@ -139,7 +139,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 7,
    "id": "dc67d139",
    "metadata": {},
    "outputs": [],
@@ -152,7 +152,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 14,
    "id": "574fb149",
    "metadata": {},
    "outputs": [
@@ -161,7 +161,7 @@
      "output_type": "stream",
      "text": [
       "┌ Warning: There is a missing value present for category 'occupation' which will be removed from Categorify dict\n",
-      "└ @ DataAugmentation /Users/manikyabardhan/.julia/packages/DataAugmentation/IwnxZ/src/rowtransforms.jl:108\n"
+      "└ @ DataAugmentation /home/lorenz/.julia/dev/DataAugmentation/src/rowtransforms.jl:108\n"
      ]
     },
     {
@@ -170,18 +170,21 @@
        "BlockMethod(TableRow{8, 6, Dict{Any, Any}} -> Label{String})"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
+    "inputblock = TableRow(cat, cont, catdict)\n",
+    "targetblock = Label(unique(data.table[:, target]))\n",
+    "\n",
     "method = BlockMethod(\n",
+    "    (inputblock, targetblock),\n",
     "    (\n",
-    "        TableRow(cat, cont, catdict), \n",
-    "        Label(unique(data.table[:, target]))\n",
-    "    ),\n",
-    "    ((FastAI.TabularPreprocessing(data)), FastAI.OneHot())\n",
+    "        setup(TabularPreprocessing, inputblock, data),\n",
+    "        FastAI.OneHot()\n",
+    "    )\n",
     ")"
    ]
   },
@@ -220,7 +223,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 15,
    "id": "2630c9d1",
    "metadata": {},
    "outputs": [
@@ -245,13 +248,13 @@
        "\\texttt{TabularPreprocessing} &  & \\textbf{\\texttt{FastAI.EncodedTableRow\\{8, 6, Dict\\{Any, Any\\}\\}}} & \\texttt{Label\\{String\\}} \\\\\n",
        "\\texttt{OneHot} & \\texttt{(x, y)} & \\texttt{FastAI.EncodedTableRow\\{8, 6, Dict\\{Any, Any\\}\\}} & \\textbf{\\texttt{FastAI.OneHotTensor\\{0, String\\}}} \\\\\n",
        "\\end{tabular}\n",
-       "Decoding a model output (\\texttt{decode(method, context, ŷ)})\n",
+       "Decoding a model output (\\texttt{decode(method, context, ŷ)})\n",
        "\n",
        "\\begin{tabular}\n",
        "{r | r | r}\n",
        "Decoding & Name & \\texttt{method.outputblock} \\\\\n",
        "\\hline\n",
-       " & \\texttt{ŷ} & \\texttt{FastAI.OneHotTensor\\{0, String\\}} \\\\\n",
+       " & \\texttt{ŷ} & \\texttt{FastAI.OneHotTensor\\{0, String\\}} \\\\\n",
        "\\texttt{OneHot} &  & \\textbf{\\texttt{Label\\{String\\}}} \\\\\n",
        "\\texttt{TabularPreprocessing} & \\texttt{target\\_pred} & \\texttt{Label\\{String\\}} \\\\\n",
        "\\end{tabular}\n"
@@ -270,11 +273,11 @@
        "| `TabularPreprocessing` |                   | **`FastAI.EncodedTableRow{8, 6, Dict{Any, Any}}`** |                      `Label{String}` |\n",
        "|               `OneHot` |          `(x, y)` |     `FastAI.EncodedTableRow{8, 6, Dict{Any, Any}}` | **`FastAI.OneHotTensor{0, String}`** |\n",
        "\n",
-       "Decoding a model output (`decode(method, context, ŷ)`)\n",
+       "Decoding a model output (`decode(method, context, ŷ)`)\n",
        "\n",
        "|               Decoding |          Name |             `method.outputblock` |\n",
        "| ----------------------:| -------------:| --------------------------------:|\n",
-       "|                        |          `ŷ` | `FastAI.OneHotTensor{0, String}` |\n",
+       "|                        |          `ŷ` | `FastAI.OneHotTensor{0, String}` |\n",
        "|               `OneHot` |               |              **`Label{String}`** |\n",
        "| `TabularPreprocessing` | `target_pred` |                  `Label{String}` |\n"
       ],
@@ -295,16 +298,16 @@
        "  \u001b[36mTabularPreprocessing\u001b[39m                 \u001b[1m\u001b[36mFastAI.EncodedTableRow{8, 6, Dict{Any, Any}}\u001b[39m\u001b[22m                  \u001b[36mLabel{String}\u001b[39m\n",
        "                \u001b[36mOneHot\u001b[39m          \u001b[36m(x, y)\u001b[39m \u001b[36mFastAI.EncodedTableRow{8, 6, Dict{Any, Any}}\u001b[39m \u001b[1m\u001b[36mFastAI.OneHotTensor{0, String}\u001b[39m\u001b[22m\n",
        "\n",
-       "  Decoding a model output (\u001b[36mdecode(method, context, ŷ)\u001b[39m)\n",
+       "  Decoding a model output (\u001b[36mdecode(method, context, ŷ)\u001b[39m)\n",
        "\n",
        "              Decoding        Name             \u001b[36mmethod.outputblock\u001b[39m\n",
        "  –––––––––––––––––––– ––––––––––– ––––––––––––––––––––––––––––––\n",
-       "                                \u001b[36mŷ\u001b[39m \u001b[36mFastAI.OneHotTensor{0, String}\u001b[39m\n",
+       "                                \u001b[36mŷ\u001b[39m \u001b[36mFastAI.OneHotTensor{0, String}\u001b[39m\n",
        "                \u001b[36mOneHot\u001b[39m                              \u001b[1m\u001b[36mLabel{String}\u001b[39m\u001b[22m\n",
        "  \u001b[36mTabularPreprocessing\u001b[39m \u001b[36mtarget_pred\u001b[39m                  \u001b[36mLabel{String}\u001b[39m"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -323,7 +326,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 16,
    "id": "e306b703-e47e-450e-83e7-34ff1aae86b4",
    "metadata": {},
    "outputs": [
@@ -338,7 +341,7 @@
        "\u001b[36m                                                              10 columns omitted\u001b[0m, \"<50k\")"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -349,7 +352,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 18,
    "id": "924c717f",
    "metadata": {},
    "outputs": [
@@ -359,7 +362,7 @@
        "(([5, 16, 2, 10, 5, 2, 3, 2], [1.6435221651965317, -0.2567538819371021, -2.751580937680526, -0.14591824281680102, -0.21665620002803673, -0.035428902921319616]), Float32[0.0, 1.0])"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -378,7 +381,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 17,
    "id": "9bdff3ae",
    "metadata": {},
    "outputs": [
@@ -419,7 +422,7 @@
        ")\u001b[90m                   # Total: 18 arrays, \u001b[39m33_413 parameters, 130.172 KiB."
       ]
      },
-     "execution_count": 9,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -438,7 +441,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 19,
    "id": "895aa501",
    "metadata": {},
    "outputs": [],
@@ -462,7 +465,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 20,
    "id": "36dc2f05",
    "metadata": {},
    "outputs": [
@@ -503,7 +506,7 @@
        ")\u001b[90m                   # Total: 18 arrays, \u001b[39m35_850 parameters, 138.828 KiB."
       ]
      },
-     "execution_count": 11,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -523,7 +526,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 21,
    "id": "64c2b78e",
    "metadata": {},
    "outputs": [
@@ -533,7 +536,7 @@
        "Learner()"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -554,15 +557,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "id": "6d67b11e",
+   "execution_count": 23,
+   "id": "4eaf21ae-93c8-4d8a-ae98-105b35f5f09a",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32mEpoch 1 TrainingPhase(): 100%|██████████████████████████| Time: 0:00:57\u001b[39m\n"
+      "\u001b[32mEpoch 1 TrainingPhase(): 100%|██████████████████████████| Time: 0:01:00\u001b[39m\n"
      ]
     },
     {
@@ -572,7 +575,7 @@
       "┌───────────────┬───────┬─────────┬──────────┐\n",
       "│\u001b[1m         Phase \u001b[0m│\u001b[1m Epoch \u001b[0m│\u001b[1m    Loss \u001b[0m│\u001b[1m Accuracy \u001b[0m│\n",
       "├───────────────┼───────┼─────────┼──────────┤\n",
-      "│ TrainingPhase │   1.0 │ 0.38906 │  0.81998 │\n",
+      "│ TrainingPhase │   1.0 │ 0.37405 │  0.82753 │\n",
       "└───────────────┴───────┴─────────┴──────────┘\n"
      ]
     },
@@ -590,7 +593,7 @@
       "┌─────────────────┬───────┬─────────┬──────────┐\n",
       "│\u001b[1m           Phase \u001b[0m│\u001b[1m Epoch \u001b[0m│\u001b[1m    Loss \u001b[0m│\u001b[1m Accuracy \u001b[0m│\n",
       "├─────────────────┼───────┼─────────┼──────────┤\n",
-      "│ ValidationPhase │   1.0 │ 0.33287 │  0.84165 │\n",
+      "│ ValidationPhase │   1.0 │ 0.39243 │  0.81782 │\n",
       "└─────────────────┴───────┴─────────┴──────────┘\n"
      ]
     },
@@ -598,7 +601,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32mEpoch 2 TrainingPhase(): 100%|██████████████████████████| Time: 0:00:03\u001b[39m\n"
+      "\u001b[32mEpoch 2 TrainingPhase(): 100%|██████████████████████████| Time: 0:00:04\u001b[39m\n"
      ]
     },
     {
@@ -608,7 +611,7 @@
       "┌───────────────┬───────┬─────────┬──────────┐\n",
       "│\u001b[1m         Phase \u001b[0m│\u001b[1m Epoch \u001b[0m│\u001b[1m    Loss \u001b[0m│\u001b[1m Accuracy \u001b[0m│\n",
       "├───────────────┼───────┼─────────┼──────────┤\n",
-      "│ TrainingPhase │   2.0 │ 0.35171 │  0.83392 │\n",
+      "│ TrainingPhase │   2.0 │ 0.35332 │  0.83909 │\n",
       "└───────────────┴───────┴─────────┴──────────┘\n"
      ]
     },
@@ -626,7 +629,7 @@
       "┌─────────────────┬───────┬─────────┬──────────┐\n",
       "│\u001b[1m           Phase \u001b[0m│\u001b[1m Epoch \u001b[0m│\u001b[1m    Loss \u001b[0m│\u001b[1m Accuracy \u001b[0m│\n",
       "├─────────────────┼───────┼─────────┼──────────┤\n",
-      "│ ValidationPhase │   2.0 │ 0.31995 │   0.8554 │\n",
+      "│ ValidationPhase │   2.0 │ 0.33674 │  0.84259 │\n",
       "└─────────────────┴───────┴─────────┴──────────┘\n"
      ]
     },
@@ -644,7 +647,7 @@
       "┌───────────────┬───────┬─────────┬──────────┐\n",
       "│\u001b[1m         Phase \u001b[0m│\u001b[1m Epoch \u001b[0m│\u001b[1m    Loss \u001b[0m│\u001b[1m Accuracy \u001b[0m│\n",
       "├───────────────┼───────┼─────────┼──────────┤\n",
-      "│ TrainingPhase │   3.0 │ 0.32234 │  0.84912 │\n",
+      "│ TrainingPhase │   3.0 │ 0.32081 │  0.85238 │\n",
       "└───────────────┴───────┴─────────┴──────────┘\n"
      ]
     },
@@ -662,7 +665,7 @@
       "┌─────────────────┬───────┬─────────┬──────────┐\n",
       "│\u001b[1m           Phase \u001b[0m│\u001b[1m Epoch \u001b[0m│\u001b[1m    Loss \u001b[0m│\u001b[1m Accuracy \u001b[0m│\n",
       "├─────────────────┼───────┼─────────┼──────────┤\n",
-      "│ ValidationPhase │   3.0 │ 0.30943 │  0.85641 │\n",
+      "│ ValidationPhase │   3.0 │ 0.31522 │  0.85259 │\n",
       "└─────────────────┴───────┴─────────┴──────────┘\n"
      ]
     }
@@ -670,19 +673,11 @@
    "source": [
     "fitonecycle!(learner, 3, 0.2)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6d5d9972-2e1c-4cf1-a8da-8750f9de041e",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 1.6.1",
+   "display_name": "Julia 1.6.2",
    "language": "julia",
    "name": "julia-1.6"
   },
@@ -690,7 +685,7 @@
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "1.6.1"
+   "version": "1.6.2"
   }
  },
  "nbformat": 4,

--- a/src/FastAI.jl
+++ b/src/FastAI.jl
@@ -129,6 +129,7 @@ export
     # encodings
     encode,
     decode,
+    setup,
     ProjectiveTransforms,
     ImagePreprocessing,
     OneHot,
@@ -141,7 +142,7 @@ export
     BlockMethod,
     describemethod,
     checkblock,
-    
+
     # learning methods
     findlearningmethods,
     ImageClassificationSingle,

--- a/src/datablock/encoding.jl
+++ b/src/datablock/encoding.jl
@@ -216,13 +216,29 @@ function decode(
                     for (block, data) in zip(blocks, datas))
 end
 
-"""
-    checkencodings()
 
-Check that `encodings` can be sequenced, i.e. given input `blocks`, the
-`encodedblock`s of every encoding can be fed into the next.
 """
-function checkencodings end
+    setup(Encoding, block, data; kwargs...)
+
+Create an encoding using statistics derived from a data container `data`
+with observations of block `block`. Used when some arguments of the encoding
+are dependent on the dataset. `data` should be the training dataset. Additional
+`kwargs` are passed through to the regular constructor of `Encoding`.
+
+## Examples
+
+```julia
+(images, labels), blocks = loaddataset("imagenette2-160", (Image, Label))
+setup(ImagePreprocessing, Image{2}(), images; buffered = false)
+```
+
+```julia
+data, block = loaddataset("adult_sample", TableRow)
+setup(TabularPreprocessing, block, data)
+```
+"""
+function setup end
+
 
 """
     testencoding(encoding, block, data)

--- a/src/encodings/imagepreprocessing.jl
+++ b/src/encodings/imagepreprocessing.jl
@@ -103,7 +103,7 @@ end
 # Setup and image statistic calculation
 
 """
-    imagedatasetstats(image, C)
+    imagestats(image, C)
 
 Compute the color channel-wise means and standard deviations of all pixels.
 `image` is converted to color type `C` (e.g. `RGB{N0f8}`, `Gray{N0f8}`)

--- a/src/encodings/imagepreprocessing.jl
+++ b/src/encodings/imagepreprocessing.jl
@@ -100,6 +100,57 @@ function decode(ip::ImagePreprocessing, context, block::ImageTensor, data)
     return copy(DataAugmentation.tensortoimage(DataAugmentation.denormalize(data, means, stds)))
 end
 
+# Setup and image statistic calculation
+
+"""
+    imagedatasetstats(image, C)
+
+Compute the color channel-wise means and standard deviations of all pixels.
+`image` is converted to color type `C` (e.g. `RGB{N0f8}`, `Gray{N0f8}`)
+before statistics are calculated.
+"""
+function imagestats(img::AbstractArray{T,N}, C) where {T,N}
+    imt = DataAugmentation.imagetotensor(map(x -> convert(C, x), img))
+    means = reshape(mean(imt; dims=1:N), :)
+    stds = reshape(std(imt; dims=1:N), :)
+    return means, stds
+end
+
+
+"""
+    imagedatasetstats(data, C[; parallel, progress])
+
+Given a data container of images `data`, compute the color channel-wise means
+and standard deviations across all observations. Images are converted to color type
+`C` (e.g. `RGB{N0f8}`, `Gray{N0f8}`) before statistics are calculated.
+
+If `progress = true`, show a progress bar.
+"""
+function imagedatasetstats(
+        data,
+        C;
+        progress=true,
+        progressfn=progress ? tqdm : identity)
+    means, stds = imagestats(getobs(data, 1), C)
+    loaderfn = d -> eachobsparallel(d, buffered=false, useprimary=true)
+
+    for (means_, stds_) in mapobs(img -> imagestats(img, C), data) |> loaderfn |> progressfn
+        means .+= means_
+        stds .+= stds_
+    end
+    return means ./ nobs(data), stds ./ nobs(data)
+end
+
+
+function setup(::Type{ImagePreprocessing}, ::Image, data; C = RGB{N0f8}, progress = false, kwargs...)
+    means, stds = imagedatasetstats(data, C; progress = progress)
+    return ImagePreprocessing(;
+        means=SVector{length(means)}(means),
+        stds=SVector{length(means)}(stds),
+        C=C,
+        kwargs...
+    )
+end
 
 # Augmentation helper
 

--- a/src/encodings/tabularpreprocessing.jl
+++ b/src/encodings/tabularpreprocessing.jl
@@ -54,6 +54,14 @@ function encode(tt::TabularPreprocessing, _, block::TableRow, row)
     (catvals, contvals)
 end
 
+
+function setup(::Type{TabularPreprocessing}, block::TableRow, data::TableDataset)
+    return TabularPreprocessing(gettransforms(data, block.catcols, block.contcols))
+end
+
+
+# Utils
+
 """
 The helper functions defined below can be used for quickly constructing a dictionary,
 which will be required for creating various tabular transformations available in DataAugmentation.jl.
@@ -107,15 +115,16 @@ end
 Returns a composition of basic tabular transformations constructed
 for the given TableDataset.
 """
-function gettransforms(td::Datasets.TableDataset)
-    catcols, contcols = getcoltypes(td)
+function gettransforms(td::TableDataset, catcols, contcols)
     normstats = FastAI.gettransformdict(td, DataAugmentation.NormalizeRow, contcols)
     fmvals = FastAI.gettransformdict(td, DataAugmentation.FillMissing, contcols)
     catdict = FastAI.gettransformdict(td, DataAugmentation.Categorify, catcols)
-
     normalize = DataAugmentation.NormalizeRow(normstats, contcols)
     categorify = DataAugmentation.Categorify(catdict, catcols)
     fm = DataAugmentation.FillMissing(fmvals, contcols)
 
     return fm |> normalize |> categorify
 end
+
+
+gettransforms(td::TableDataset) = gettransforms(td, getcoltypes(td)...)

--- a/src/fasterai/learningmethods.jl
+++ b/src/fasterai/learningmethods.jl
@@ -1,16 +1,19 @@
 # ## Computer vision
 
 function ImageClassificationSingle(
-		blocks::Tuple{<:Image{N},<:Label};
+		blocks::Tuple{<:Image{N},<:Label},
+        data=nothing;
 		size=ntuple(i -> 128, N),
 		aug_projections=DataAugmentation.Identity(),
 		aug_image=DataAugmentation.Identity(),
+        C=RGB{N0f8},
+        computestats=false,
 	) where N
 	return BlockMethod(
 		blocks,
 		(
 			ProjectiveTransforms(size; augmentations=aug_projections),
-			ImagePreprocessing(),
+			getimagepreprocessing(data, computestats; C=C, augmentations=aug_image),
         	OneHot()
 		)
 	)
@@ -18,11 +21,23 @@ end
 
 """
     ImageClassificationSingle(size, classes; kwargs...)
+    ImageClassificationSingle(blocks[, data]; kwargs...)
 
 Learning method for single-label image classification. Images are
 resized to `size` and classified into one of `classes`.
 
 Use [`ImageClassificationMulti`](#) for the multi-class setting.
+
+## Keyword arguments
+
+- `computestats = false`: Whether to compute image statistics on dataset `data` or use
+    default ImageNet stats.
+- `aug_projections = `[`DataAugmentation.Identity`](#): augmentation to apply during
+  [`ProjectiveTransforms`](#) (resizing and cropping)
+- `aug_image = `[`DataAugmentation.Identity`](#): pixel-level augmentation to apply during
+  [`ImagePreprocessing`](#)
+- `C = RGB{N0f8}`: Color type images are converted to before further processing. Use `Gray{N0f8}`
+    for grayscale images.
 """
 function ImageClassificationSingle(size::NTuple{N,Int}, classes::AbstractVector; kwargs...) where N
     blocks = (Image{N}(), Label(classes))
@@ -34,16 +49,19 @@ registerlearningmethod!(FASTAI_METHOD_REGISTRY, ImageClassificationSingle, (Imag
 # ---
 
 function ImageClassificationMulti(
-		blocks::Tuple{<:Image{N},<:LabelMulti};
+		blocks::Tuple{<:Image{N},<:LabelMulti},
+        data = nothing;
 		size=ntuple(i -> 128, N),
 		aug_projections=DataAugmentation.Identity(),
 		aug_image=DataAugmentation.Identity(),
+        C=RGB{N0f8},
+        computestats=false,
 	) where N
 	return BlockMethod(
 		blocks,
 		(
 			ProjectiveTransforms(size; augmentations=aug_projections),
-			ImagePreprocessing(augmentations=aug_image),
+			getimagepreprocessing(data, computestats; C=C, augmentations=aug_image),
         	OneHot()
 		)
 	)
@@ -57,6 +75,17 @@ Learning method for multi-label image classification. Images are
 resized to `size` and classified into multiple of `classes`.
 
 Use [`ImageClassificationSingle`](#) for the single-class setting.
+
+## Keyword arguments
+
+- `computestats = false`: Whether to compute image statistics on dataset `data` or use
+    default ImageNet stats.
+- `aug_projections = `[`DataAugmentation.Identity`](#): augmentation to apply during
+  [`ProjectiveTransforms`](#) (resizing and cropping)
+- `aug_image = `[`DataAugmentation.Identity`](#): pixel-level augmentation to apply during
+  [`ImagePreprocessing`](#)
+- `C = RGB{N0f8}`: Color type images are converted to before further processing. Use `Gray{N0f8}`
+    for grayscale images.
 """
 function ImageClassificationMulti(size::NTuple{N,Int}, classes::AbstractVector; kwargs...) where N
     blocks = (Image{N}(), LabelMulti(classes))
@@ -69,16 +98,19 @@ registerlearningmethod!(FASTAI_METHOD_REGISTRY, ImageClassificationMulti, (Image
 # ---
 
 function ImageSegmentation(
-		blocks::Tuple{<:Image{N},<:Mask{N}};
+		blocks::Tuple{<:Image{N},<:Mask{N}},
+        data=nothing;
 		size=ntuple(i -> 128, N),
 		aug_projections=DataAugmentation.Identity(),
 		aug_image=DataAugmentation.Identity(),
+        C=RGB{N0f8},
+        computestats=false,
 	) where N
 	return BlockMethod(
 		blocks,
 		(
 			ProjectiveTransforms(size; augmentations=aug_projections),
-			ImagePreprocessing(augmentations=aug_image),
+			getimagepreprocessing(data, computestats; C=C, augmentations=aug_image),
         	OneHot()
 		)
 	)
@@ -90,10 +122,21 @@ end
 
 Learning method for image segmentation. Images are
 resized to `size` and a class is predicted for every pixel.
+
+## Keyword arguments
+
+- `computestats = false`: Whether to compute image statistics on dataset `data` or use
+    default ImageNet stats.
+- `aug_projections = `[`DataAugmentation.Identity`](#): augmentation to apply during
+  [`ProjectiveTransforms`](#) (resizing and cropping)
+- `aug_image = `[`DataAugmentation.Identity`](#): pixel-level augmentation to apply during
+  [`ImagePreprocessing`](#)
+- `C = RGB{N0f8}`: Color type images are converted to before further processing. Use `Gray{N0f8}`
+    for grayscale images.
 """
 function ImageSegmentation(size::NTuple{N,Int}, classes::AbstractVector; kwargs...) where N
     blocks = (Image{N}(), Mask{N}(classes))
-    return ImageSegmentation(blocks; size, kwargs...)
+    return ImageSegmentation(blocks; size=size, kwargs...)
 end
 
 registerlearningmethod!(FASTAI_METHOD_REGISTRY, ImageSegmentation, (Image, Mask))
@@ -103,16 +146,19 @@ registerlearningmethod!(FASTAI_METHOD_REGISTRY, ImageSegmentation, (Image, Mask)
 
 
 function ImageKeypointRegression(
-        blocks::Tuple{<:Image{N},<:Keypoints{N}};
+        blocks::Tuple{<:Image{N},<:Keypoints{N}},
+        data=nothing;
         size=ntuple(i -> 128, N),
 		aug_projections=DataAugmentation.Identity(),
 		aug_image=DataAugmentation.Identity(),
+        C=RGB{N0f8},
+        computestats=false,
     ) where N
     return BlockMethod(
         blocks,
         (
 			ProjectiveTransforms(size; augmentations=aug_projections),
-			ImagePreprocessing(augmentations=aug_image),
+			getimagepreprocessing(data, computestats; C=C, augmentations=aug_image),
             KeypointPreprocessing(size),
         )
     )
@@ -132,68 +178,99 @@ end
 
 registerlearningmethod!(FASTAI_METHOD_REGISTRY, ImageKeypointRegression, (Image, Keypoints))
 
+
+function getimagepreprocessing(data, computestats::Bool; kwargs...)
+    if isnothing(data) && computestats
+        error("If `computestats` is `true`, you have to pass in a data container `data`.")
+    end
+    return if computestats
+        setup(ImagePreprocessing, Image{2}(), data; kwargs...)
+    else
+        ImagePreprocessing(; kwargs...)
+    end
+end
+
+
 # ## Tabular
 
 function TabularClassificationSingle(
-        blocks::Tuple{<:TableRow, <:Label}; 
-        data::TableDataset)
+        blocks::Tuple{<:TableRow, <:Label},
+        data)
+    tabledata, targetdata = data
+    tabledata isa TableDataset || error("`data` needs to be a tuple of a `TableDataset` and targets")
+
     return BlockMethod(
         blocks,
         (
-            TabularPreprocessing(data),
+            setup(TabularPreprocessing, blocks[1], tabledata),
             OneHot()
         )
     )
 end
 
 """
-    TabularClassificationSingle(catcols, contcols, classes; data)
+    TabularClassificationSingle(blocks, data)
 
 Learning method for single-label tabular classification. Continuous columns are
-normalized and missing values are filled, categorical columns are label encoded 
+normalized and missing values are filled, categorical columns are label encoded
 taking into account any missing values which might be present. The target value
-is predicted from `classes`.
+is predicted from `classes`. `blocks` should be an input and target block
+`(TableRow(...), Label(...))`.
+
+    TabularClassificationSingle(classes, tabledata [; catcols, contcols])
+
+Construct learning method with `classes` to classify into and a `TableDataset`
+`tabledata`. The column names can be passed in or guessed from the data.
 """
 function TabularClassificationSingle(
-        catcols::NTuple, 
-        contcols::NTuple, 
-        classes::AbstractVector;
-        data::Datasets.TableDataset)
+        classes::AbstractVector,
+        tabledata::TableDataset;
+        catcols = nothing,
+        contcols = nothing)
+
     blocks = (
-        TableRow(catcols, contcols, gettransformdict(data, DataAugmentation.Categorify, catcols)), 
+        setup(TableRow, tabledata; catcols = catcols, contcols = contcols),
         Label(classes)
     )
-    return TabularClassificationSingle(blocks; data = data)
+    return TabularClassificationSingle(blocks, (tabledata, nothing))
 end
 
 # ---
 
 function TabularRegression(
-        blocks::Tuple{<:TableRow, <:Continuous}; 
-        data::TableDataset)
+        blocks::Tuple{<:TableRow, <:Continuous},
+        data)
+    tabledata, targetdata = data
+    tabledata isa TableDataset || error("`data` needs to be a tuple of a `TableDataset` and targets")
     return BlockMethod(
         blocks,
-        (TabularPreprocessing(data),),
+        (setup(TabularPreprocessing, blocks[1], tabledata),),
         outputblock=blocks[2]
     )
 end
 
 """
-    TabularRegression(catcols, contcols; kwargs...)
+    TabularRegression(blocks, data)
 
-Learning method for single-label tabular classification. Continuous columns are
-normalized and missing values are filled, categorical columns are label encoded 
-taking into account any missing values which might be present. The target value
-is predicted from `classes`.
+Learning method for tabular regression. Continuous columns are
+normalized and missing values are filled, categorical columns are label encoded
+taking into account any missing values which might be present.
+ `blocks` should be an input and target block `(TableRow(...), Continuous(...))`.
+
+    TabularRegression(n, tabledata [; catcols, contcols])
+
+Construct learning method with `classes` to classify into and a `TableDataset`
+`tabledata`. The column names can be passed in or guessed from the data. The
+regression target is a vector of `n` values.
 """
-
 function TabularRegression(
-        catcols::NTuple{M}, 
-        contcols::NTuple{N};
-        data::Datasets.TableDataset) where {M, N}
+        n::Int,
+        tabledata::TableDataset;
+        catcols = nothing,
+        contcols = nothing)
     blocks = (
-        TableRow(catcols, contcols, gettransformdict(data, DataAugmentation.Categorify, catcols)), 
-        Continuous(N)
+        setup(TableRow, tabledata; catcols=catcols, contcols=contcols),
+        Continuous(n)
     )
-    return TabularRegression(blocks; data = data)
+    return TabularRegression(blocks, (tabledata, nothing))
 end

--- a/test/encodings/imagepreprocessing.jl
+++ b/test/encodings/imagepreprocessing.jl
@@ -1,3 +1,5 @@
+include("../imports.jl")
+
 
 @testset "ImagePreprocessing" begin
     encfns = [
@@ -28,9 +30,37 @@
         img = rand(RGB{N0f8}, 10, 10, 10)
         testencoding(enc, block, img)
 
-        enc = ImagePreprocessing(buffered = false)
+        enc = ImagePreprocessing(buffered=false)
         block = Image{3}()
         img = rand(RGB{N0f8}, 10, 10, 10)
         testencoding(enc, block, img)
+    end
+
+    @testset ExtendedTestSet "imagedatasetstats" begin
+
+        @testset ExtendedTestSet "RGB" begin
+            data = [zeros(RGB{Float32}, 10, 10), ones(RGB{Float32}, 10, 10)]
+            means, stds = imagedatasetstats(data, RGB{N0f8}; progress=false)
+            @test means ≈ [0.5, 0.5, 0.5]
+            @test stds ≈ [0., 0., 0.]
+        end
+
+        @testset ExtendedTestSet "Gray" begin
+            data = [zeros(Gray{Float32}, 10, 10), ones(Gray{Float32}, 10, 10)]
+            means, stds = imagedatasetstats(data, Gray{N0f8}; progress=false)
+            @test means ≈ [0.5]
+            @test stds ≈ [0.]
+        end
+
+    end
+
+    @testset ExtendedTestSet "setup" begin
+        data = [
+            zeros(10, 10),
+            ones(10, 10),
+        ]
+        enc = setup(ImagePreprocessing, Image{2}(), data, C = Gray{N0f8})
+        @test enc.stats[1] ≈ [0.5]
+        @test enc.stats[2] ≈ [0.]
     end
 end

--- a/test/encodings/tabularpreprocessing.jl
+++ b/test/encodings/tabularpreprocessing.jl
@@ -1,3 +1,5 @@
+include("../imports.jl")
+
 
 @testset "TabularPreprocessing" begin
     cols = [:col1, :col2, :col3, :col4, :col5]
@@ -12,20 +14,24 @@
     col3_mean, col3_std = 15, 1
 
     normdict = Dict(
-        :col1 => (col1_mean, col1_std), 
-        :col2 => (col2_mean, col2_std), 
+        :col1 => (col1_mean, col1_std),
+        :col2 => (col2_mean, col2_std),
         :col3 => (col3_mean, col3_std)
     )
 
     tfm = TabularPreprocessing(
         NormalizeRow(normdict, contcols)
     )
-    
+
     block = TableRow(
-        catcols, 
-        contcols, 
+        catcols,
+        contcols,
         Dict(:col4=>["a", "b"], :col5=>["x", "y", "z"])
     )
 
     testencoding(tfm, block, row)
+
+    @testset ExtendedTestSet "" begin
+        testencoding(setup(TabularPreprocessing, block, TableDataset(DataFrame([row, row]))), block, row)
+    end
 end

--- a/test/imports.jl
+++ b/test/imports.jl
@@ -3,7 +3,8 @@ using Colors: RGB, N0f8, Gray
 using FastAI
 using FastAI: ParamGroups, IndexGrouper, getgroup, DiscriminativeLRs, decay_optim
 import FastAI: Image, Keypoints, Mask, testencoding, Label, OneHot, ProjectiveTransforms,
-    encodedblock, decodedblock, encode, decode, mockblock, checkblock, Block, Encoding
+    encodedblock, decodedblock, encode, decode, mockblock, checkblock, Block, Encoding,
+    imagedatasetstats
 using FilePathsBase
 using FastAI.Datasets
 using FastAI.Models

--- a/test/methods/tabularclassification.jl
+++ b/test/methods/tabularclassification.jl
@@ -3,7 +3,8 @@ include("../imports.jl")
 @testset "TabularClassificationSingle" begin
     df = DataFrame(A = 1:4, B = ["M", "F", "F", "M"], C = ["P", "F", "P", "F"])
     td = TableDataset(df)
-    method = TabularClassificationSingle((:B,), (:A,), ["P", "F"]; data = td)
+
+    method = TabularClassificationSingle(["P", "F"], td; catcols=(:B,), contcols=(:A,), )
     testencoding(method.encodings, method.blocks)
     DLPipelines.checkmethod_core(method)
     @test_nowarn methodlossfn(method)
@@ -25,4 +26,7 @@ include("../imports.jl")
         @test y ≈ [1, 0]
     end
 
+
+    @test_nowarn TabularClassificationSingle(["P", "F"], td)
+    @test TabularClassificationSingle(["P", "F"], td).blocks[1].catcols == (:B, :C)
 end

--- a/test/methods/tabularregression.jl
+++ b/test/methods/tabularregression.jl
@@ -3,7 +3,8 @@ include("../imports.jl")
 @testset "TabularRegression" begin
     df = DataFrame(A = 1:4, B = ["M", "F", "F", "M"], C = 10:13)
     td = TableDataset(df)
-    method = TabularRegression((:B,), (:A,); data = td)
+    targets = [rand(2) for _ in 1:4]
+    method = TabularRegression(2, td; catcols=(:B,), contcols=(:A,))
     testencoding(method.encodings, method.blocks)
     DLPipelines.checkmethod_core(method)
     @test_nowarn methodlossfn(method)
@@ -25,4 +26,5 @@ include("../imports.jl")
         @test target == y
     end
 
+    @test_nowarn method = TabularRegression(2, td)
 end

--- a/toc.md
+++ b/toc.md
@@ -8,6 +8,7 @@
     - Intermediate
         - [Image segmentation](notebooks/imagesegmentation.ipynb)
         - [Keypoint regression](notebooks/keypointregression.ipynb)
+        - [Tabular classification](notebooks/tabularclassification.ipynb)
         - [Data containers](docs/data_containers.md)
         - [Saving and loading models](notebooks/serialization.ipynb)
     - Advanced


### PR DESCRIPTION
This PR adds functionality for setting up encodings that need access to a data container, e.g. to compute some statistics over each observation.

The interface looks something like this:

```julia
"""
    setup(Encoding, block, data; kwargs...)

Create an encoding using statistics derived from a data container `data`
with observations of block `block`. Used when some arguments of the encoding
are dependent on the dataset. `data` should be the training dataset. Additional
`kwargs` are passed through to the regular constructor of `Encoding`.

## Examples

``julia
(images, labels), blocks = loaddataset("imagenette2-160", (Image, Label))
setup(ImagePreprocessing, Image{2}(), images; buffered = false)
``

``julia
data, block = loaddataset("adult_sample", TableRow)
setup(TabularPreprocessing, block, data)
``
"""
function setup end
```

Beside the `setup` implementation, this addition will also change the interface of the learning method functions like `ImageClassificationSingle` as they now take a data container `data` as a second argument in case the setup step is needed.

Specifically, the computer vision methods can compute normalization stats on the image (which is turned off by default for performance reasons; there'll be a flag) and the tabular methods compute stats for `TabularPreprocessing` on a table dataset.

To-Dos:

- implement, test, and document `setup` for
  - [x] `ImagePreprocessing`
  - [x] `TabularPrepreprocessing`
- [x] update learning method functions to use setup
- docs
  - [x] update quickstart docs to include tabular tasks (this was pending on this functionality)
  - [x] update tabular clf notebook
- [x] update CHANGELOG.md

