### PR TITLE
Any-length dimensions for `Bounded`

### DIFF
--- a/src/blocks/many.jl
+++ b/src/blocks/many.jl
@@ -17,7 +17,7 @@ end
 
 FastAI.checkblock(many::Many, obss) =
     all(checkblock(wrapped(many), obs) for obs in obss)
-FastAI.mockblock(many::Many) = [mockblock(wrapped(many)), mockblock(wrapped(many))]
+FastAI.mockblock(many::Many) = [mockblock(wrapped(many)) for _ in 1:rand(1:3)]
 
 function FastAI.encode(enc::Encoding, ctx, many::Many, obss)
     return map(obss) do obs

--- a/src/datablock/wrappers.jl
+++ b/src/datablock/wrappers.jl
@@ -2,7 +2,9 @@
 
 abstract type WrapperBlock <: AbstractBlock end
 
-wrapped(w::WrapperBlock) = w.block
+Base.parent(w::WrapperBlock) = w.block
+Base.parent(b::Block) = b
+wrapped(w::WrapperBlock) = wrapped(parent(w))
 wrapped(b::Block) = b
 function setwrapped(w::WrapperBlock, b)
     return Setfield.@set w.block = b
@@ -61,7 +63,7 @@ end
 
 function encodedblock(enc::Encoding, wrapper::WrapperBlock, ::PropagateSameBlock)
     inner = encodedblock(enc, wrapped(wrapper))
-    inner == wrapped(block) && return setwrapped(wrapper, inner)
+    inner == wrapped(wrapped) && return setwrapped(wrapper, inner)
     return inner
 end
 

--- a/src/datablock/wrappers.jl
+++ b/src/datablock/wrappers.jl
@@ -63,7 +63,7 @@ end
 
 function encodedblock(enc::Encoding, wrapper::WrapperBlock, ::PropagateSameBlock)
     inner = encodedblock(enc, wrapped(wrapper))
-    inner == wrapped(wrapped) && return setwrapped(wrapper, inner)
+    inner == wrapped(wrapper) && return setwrapped(wrapper, inner)
     return inner
 end
 


### PR DESCRIPTION
This adds the option to have some dimensions allow any length for `Bounded` blocks.

Before, each dimension had to have a fixed length, i.e. `Bounded(Image{2}(), (16, 16))`. Now a dimension with arbitrary length can be indicated by a colon `:`: `Bounded(Image{2}(), (:, 16)` is a `(h, 16)`-image.