### PR TITLE
Added Time Series Container and Block

### DIFF
--- a/src/TimeSeries/blocks/timeseries.jl
+++ b/src/TimeSeries/blocks/timeseries.jl
@@ -1,0 +1,24 @@
+
+struct TimeSeries{M,N} <: Block end
+
+function checkblock(::TimeSeries{M,N}, obs::AbstractArray{T,2}) where {M,N,T<:Number}
+    size(obs) == (M,N)
+end
+
+mockblock(::TimeSeries{M,N}) where {M,N} = rand(Float64, (M,N))    
+
+function setup(::Type{TimeSeries}, data)
+    # N,M = size(data[1,:,:])
+    N,M = size(getobs(data, 1))
+    return TimeSeries{N,M}()
+end
+
+# visualization
+
+function showblock!(io, ::ShowText, block::TimeSeries, obs)
+    plot = UnicodePlots.lineplot(obs[1,:])
+    for j=2:size(obs,1)
+        UnicodePlots.lineplot!(plot, obs[j,:])
+    end
+    print(io, plot)
+end

--- a/src/datasets/Datasets.jl
+++ b/src/datasets/Datasets.jl
@@ -63,6 +63,7 @@ export
     # primitive containers
     FileDataset,
     TableDataset,
+    TimeSeriesDataset,
 
     # utilities
     isimagefile,

--- a/src/datasets/containers.jl
+++ b/src/datasets/containers.jl
@@ -91,6 +91,26 @@ LearnBase.nobs(dataset::TableDataset{<:DataFrame}) = nrow(dataset.table)
 LearnBase.getobs(dataset::TableDataset{<:CSV.File}, idx) = dataset.table[idx]
 LearnBase.nobs(dataset::TableDataset{<:CSV.File}) = length(dataset.table)
 
+# TimeSeries Dataset
+
+struct TimeSeriesDataset{}
+    table::AbstractArray{Float64,3}
+end 
+
+function TimeSeriesDataset(path::AbstractPath)
+    mat = Matrix(DataFrame(CSV.File(path,header=0)))
+    N,M = size(mat)
+    table = reshape(mat, (N,1,M))
+    TimeSeriesDataset(table)
+end 
+
+function LearnBase.getobs(dataset::TimeSeriesDataset, idx)
+    dataset.table[idx,:,:]
+end
+
+function LearnBase.nobs(dataset::TimeSeriesDataset) 
+    size(dataset.table)[1]
+end
 
 # ## Tests
 


### PR DESCRIPTION
Added Time Series Container and Block. Currently can only load univariate time series. This is work in progress for issue #155 .
I was planning to add `loaddataset` function for such datasets. Currently all datasets have the same root URL :- "https://s3.amazonaws.com/fast-ai-" . For time series datasets the root url is different so i think we can proceed by add `root_url` field in the `FastAIDataset` structure.
How does this sound ? 