### PR TITLE
Blocks and container added for Text Dataset

### DIFF
--- a/src/FastAI.jl
+++ b/src/FastAI.jl
@@ -110,6 +110,9 @@ export Vision
 include("Tabular/Tabular.jl")
 @reexport using .Tabular
 
+include("Text/Text.jl")
+@reexport using .Text
+
 
 include("deprecations.jl")
 export
@@ -170,6 +173,7 @@ export
     LabelMulti,
     Many,
     TableRow,
+    TextRow,
     Continuous,
     Image,
 

--- a/src/Text/Text.jl
+++ b/src/Text/Text.jl
@@ -1,0 +1,56 @@
+module Text
+
+
+using ..FastAI
+using ..FastAI:
+    # blocks
+    Block, WrapperBlock, AbstractBlock, OneHotTensor, OneHotTensorMulti, Label,
+    LabelMulti, wrapped, Continuous, getencodings, getblocks, encodetarget, encodeinput,
+    # encodings
+    Encoding, StatefulEncoding, OneHot,
+    # visualization
+    ShowText,
+    # other
+    Context, Training, Validation, FASTAI_METHOD_REGISTRY, registerlearningtask!
+
+# for tests
+using ..FastAI: testencoding
+
+# extending
+import ..FastAI:
+    blockmodel, blockbackbone, blocklossfn, encode, decode, checkblock,
+    encodedblock, decodedblock, showblock!, mockblock, setup
+
+
+import DataAugmentation
+import DataFrames: DataFrame
+import Flux: Embedding, Chain, Dropout, Dense, Parallel
+import PrettyTables
+import Requires: @require
+import ShowCases: ShowCase
+import Tables
+import Statistics
+
+using InlineTest
+
+
+# Blocks
+include("blocks/textrow.jl")
+
+# Encodings
+include("recipes.jl")
+
+
+function __init__()
+    _registerrecipes()
+    @require Makie="ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a" begin
+        import .Makie
+        import .Makie: @recipe, @lift
+        import .FastAI: ShowMakie
+        include("makie.jl")
+    end
+end
+
+export TextRow
+
+end

--- a/src/Text/blocks/textrow.jl
+++ b/src/Text/blocks/textrow.jl
@@ -1,0 +1,70 @@
+
+
+# TextRow
+
+"""
+    TextRow{M, N}(catcols, contcols, categorydict) <: Block
+
+`Block` for table rows with M categorical and N continuous columns. `data`
+is valid if it satisfies the `AbstractRow` interface in Tables.jl, values
+present in indices for categorical and continuous columns are consistent,
+and `data` is indexable by the elements of `catcols` and `contcols`.
+"""
+struct TextRow{M,N,T} <: Block
+    catcols::NTuple{M}
+    contcols::NTuple{N}
+    categorydict::T
+end
+
+function TextRow(catcols, contcols, categorydict)
+    TextRow{length(catcols),length(contcols)}(catcols, contcols, categorydict)
+end
+
+function checkblock(block::TextRow, x)
+    columns = Tables.columnnames(x)
+    (
+        all(col -> col ∈ columns, (block.catcols..., block.contcols...)) &&
+        all(
+            col ->
+                haskey(block.categorydict, col) &&
+                    (ismissing(x[col]) || x[col] ∈ block.categorydict[col]),
+            block.catcols,
+        ) &&
+        all(col -> ismissing(x[col]) || x[col] isa Number, block.contcols)
+    )
+end
+
+function mockblock(block::TextRow)
+    cols = (block.catcols..., block.contcols...)
+    vals = map(cols) do col
+        col in block.catcols ? rand(block.categorydict[col]) : rand()
+    end
+    return NamedTuple(zip(cols, vals))
+end
+
+"""
+    setup(TextRow, data[; catcols, contcols])
+
+Create a `TextRow` block from data container `data::TextDataset`. If the
+categorical and continuous columns are not specified manually, try to
+guess them from the dataset's column types.
+"""
+function setup(::Type{TextRow}, data; catcols=nothing, contcols=nothing)
+    catcols_, contcols_ = getcoltypes(data)
+    catcols = isnothing(catcols) ? catcols_ : catcols
+    contcols = isnothing(contcols) ? contcols_ : contcols
+
+    return TextRow(
+        catcols,
+        contcols,
+        gettransformdict(data, DataAugmentation.Categorify, catcols),
+    )
+end
+
+function Base.show(io::IO, block::TextRow)
+    print(io, ShowCase(block, (:catcols, :contcols), show_params=false, new_lines=true))
+end
+
+# ## Interpretation
+
+# function showblock!(io, ::ShowText, block::TextRow, obs) end

--- a/src/Text/makie.jl
+++ b/src/Text/makie.jl
@@ -1,0 +1,1 @@
+# No Makie recipes yet, text is better I guess

--- a/src/Text/recipes.jl
+++ b/src/Text/recipes.jl
@@ -1,0 +1,9 @@
+
+"""
+    TextDatasetRecipe(tablefile; catcols, contcols, kwargs...])
+
+Recipe for loading a `TextDataset`. `tablefile` is the path of a file that can
+be read as a table. `catcols` and `contcols` indicate the categorical and
+continuous columns of the text table. If they are not given, they are detected
+automatically.
+"""

--- a/src/datasets/Datasets.jl
+++ b/src/datasets/Datasets.jl
@@ -63,6 +63,7 @@ export
     # primitive containers
     FileDataset,
     TableDataset,
+    TextDataset,
 
     # utilities
     isimagefile,


### PR DESCRIPTION
Registered the NLP ( Text ) dataset to be added in the upcoming months. Added functions for the blocks of the Text dataset.
All the nlp dataset ( which are registered ) along with their forthcoming models will be added . Exploring Julia Text, MLutils and other package along with FastAI concepts so that these datasets can work well with Flux. As almost all the text datasets are in csv format it will be easily lo load them and create the corresponding container, working on further concepts to implement these text datasets.

Currently I have added the entire basic structure of the Text Data comprising of the blocks and the containers. Have researched a lot since a week ( understanding FastAI docs and codebase ). Currently working on adding textrow block along with the recipes.jl.
Also currently working on two datasets "imdb" and "amazon_review_full" as both have different folder structure so different blocks would be required. Also going through the 2 papers which have built state of the art model for these two datasets and working on its implementation. Any reviews thus far will be appreciated.

Reopened PR#100 , needed to delete that repo due to merging issue.