### PR TITLE
Ports over `_predictx` from DLPipelines.jl

### DIFF
--- a/src/datasets/containers.jl
+++ b/src/datasets/containers.jl
@@ -35,7 +35,7 @@ Load a file from disk into the appropriate format.
 function loadfile(file::String)
     if isimagefile(file)
         # faster image loading
-        return FileIO.load(file, view = true)
+        return FileIO.load(file)
     elseif endswith(file, ".csv")
         return DataFrame(CSV.File(file))
     else

--- a/src/interpretation/makie/showmakie.jl
+++ b/src/interpretation/makie/showmakie.jl
@@ -107,12 +107,12 @@ showblocks!(grid, backend::ShowMakie, block, obss::AbstractVector) =
 
 function showblock!(grid, ::ShowMakie, block::Label, obs)
     ax = cleanaxis(grid[1, 1])
-    text!(ax, string(obs), space = :data)
+    M.text!(ax, string(obs), space = :data)
 end
 
 function showblock!(grid, ::ShowMakie, block::LabelMulti, obs)
     ax = cleanaxis(grid[1, 1])
-    text!(ax, join(string.(obs), "\n"), space = :data)
+    M.text!(ax, join(string.(obs), "\n"), space = :data)
 end
 
 

--- a/src/tasks/check.jl
+++ b/src/tasks/check.jl
@@ -37,3 +37,15 @@ function checktask_core(
         end
     end
 end
+
+
+function _predictx(method, model, x, device = identity)
+    if shouldbatch(method)
+        x = DataLoaders.collate([x])
+    end
+    ŷs = device(model)(device(x))
+    if shouldbatch(method)
+        ŷ = ŷs[((:) for _ in 1:ndims(ŷs)-1)..., 1]
+    end
+    return ŷ
+end


### PR DESCRIPTION
Fixes the following issues
- missing `_predictx`: This was missed when removing DLPipelines.jl and is required by the task test suite  `checktask_core`
- unqualified Makie symbols
- `load(file; view = true)` for image loading no longer exists in newer ImageIO.jl versions