### PR TITLE
Keypoint regression example

### DIFF
--- a/notebooks/keypointregression.ipynb
+++ b/notebooks/keypointregression.ipynb
@@ -413,14 +413,7 @@
     }
    ],
    "source": [
-    "DLPipelines.decodeŷ(task, Training(), y)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We should also visualize our data to make sure that after all the encoding it still makes sense and the keypoint is properly aligned with the head on the image. The visualizations are derived from the data blocks we used when defining our `BlockTask`."
+    "FastAI.decodeypred(task, Training(), y)"
    ]
   },
   {

--- a/notebooks/keypointregression.ipynb
+++ b/notebooks/keypointregression.ipynb
@@ -18,22 +18,12 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "┌ Info: Precompiling FastAI [5d0beca9-ade8-49ae-ad0b-a3cf890e669f]\n",
-      "└ @ Base loading.jl:1342\n",
-      "WARNING: using Makie.Label in module FastAI conflicts with an existing identifier.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import CairoMakie; CairoMakie.activate!(type=\"png\")\n",
     "using DelimitedFiles: readdlm\n",
     "using FastAI\n",
-    "using FastAI.FilePathsBase, FastAI.StaticArrays, FastAI.DLPipelines\n",
+    "using FastAI.FilePathsBase, FastAI.StaticArrays\n",
     "import FastAI.DataAugmentation"
    ]
   },

--- a/notebooks/keypointregression.ipynb
+++ b/notebooks/keypointregression.ipynb
@@ -348,8 +348,8 @@
     }
    ],
    "source": [
-    "sz = (128, 128)\n",
-    "task = BlockTask(\n",
+    "sz = (224, 224)\n",
+    "task = SupervisedTask(\n",
     "    (Image{2}(), Keypoints{2}(1)),\n",
     "    (\n",
     "        ProjectiveTransforms(sz, buffered=true, augmentations=augs_projection(max_warp=0)),\n",
@@ -374,7 +374,7 @@
     {
      "data": {
       "text/plain": [
-       "(\"128×128×3 Array{Float32, 3}\", Float32[0.33977616, 0.19801295])"
+       "(\"224×224×3 Array{Float32, 3}\", Float32[-0.11184323, 0.52864575])"
       ]
      },
      "execution_count": 11,
@@ -404,7 +404,7 @@
      "data": {
       "text/plain": [
        "1-element Vector{SVector{2, Float32}}:\n",
-       " [85.745674, 76.67283]"
+       " [99.47356, 171.20831]"
       ]
      },
      "execution_count": 12,

--- a/notebooks/keypointregression.ipynb
+++ b/notebooks/keypointregression.ipynb
@@ -535,6 +535,7 @@
     }
    ],
    "source": [
+    "import Flux\n",
     "learner = Learner(\n",
     "    model,\n",
     "    (traindl, validdl),\n",

--- a/notebooks/keypointregression.ipynb
+++ b/notebooks/keypointregression.ipynb
@@ -188,7 +188,7 @@
     {
      "data": {
       "text/plain": [
-       "loadannotfile (generic function with 2 tasks)"
+       "loadannotfile (generic function with 2 methods)"
       ]
      },
      "execution_count": 6,
@@ -292,7 +292,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Before we can start using this data container for training, we need to split into a training and validation dataset. Since there are 13 different persons with many images each, randomly splitting the container does not make sense. The validation dataset would then contain many images that are very similar to those seen in training, and would hence say little about the generalization ability of a model. We instead use the first 12 subjects as a training dataset and validate on the last."
+    "Before we can start using this data container for training, we need to split it into a training and validation dataset. Since there are 13 different persons with many images each, randomly splitting the container does not make sense. The validation dataset would then contain many images that are very similar to those seen in training, and would hence say little about the generalization ability of a model. We instead use the first 12 subjects as a training dataset and validate on the last."
    ]
   },
   {
@@ -463,7 +463,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We'll use a modified ResNet as a model backbone. and add a couple layers that regress the keypoint. [`taskmodel`](#) knows how to do this by looking at the data blocks used and calling [`blockmodel`](#)`(KepointTensor{2, Float32}((1,)), KeypointTensor{2, Float32}((1,)), backbone)`."
+    "We'll use a modified ResNet as a model backbone. and add a couple layers that regress the keypoint. [`taskmodel`](#) knows how to do this by looking at the data blocks used and calling [`blockmodel`](#)`(KeypointTensor{2, Float32}((1,)), KeypointTensor{2, Float32}((1,)), backbone)`."
    ]
   },
   {

--- a/notebooks/keypointregression.ipynb
+++ b/notebooks/keypointregression.ipynb
@@ -339,7 +339,7 @@
     {
      "data": {
       "text/plain": [
-       "BlockTask(Image{2} -> Keypoints{2, 1})"
+       "SupervisedTask(Image{2} -> Keypoints{2, 1})"
       ]
      },
      "execution_count": 10,

--- a/notebooks/keypointregression.ipynb
+++ b/notebooks/keypointregression.ipynb
@@ -22,7 +22,7 @@
    "source": [
     "import CairoMakie; CairoMakie.activate!(type=\"png\")\n",
     "using DelimitedFiles: readdlm\n",
-    "using FastAI\n",
+    "using FastAI, ImageShow\n",
     "using FastAI.FilePathsBase, FastAI.StaticArrays\n",
     "import FastAI.DataAugmentation"
    ]


### PR DESCRIPTION
Running these steps in my REPL worked but only gave me the following problem
- the `FastAI.decodeypred(task, Training(), y)` check does not have the same coordinates as the original keypoint `k`

Running it in a local notebook gives me the following problems
- The first image plotted with `DataAugmentation.showitems` looks like this
![Screenshot 2022-04-27 at 09 27 02](https://user-images.githubusercontent.com/40626188/165464619-af70862b-98cf-4585-9627-368c3a3617aa.png)
 - The kernel dies every time I try to run `showbatch(task, (xs, ys))`

Can someone try to reproduce this? I'm not sure whether these are environments problems (running with julia 1.7.2 and the mac M1 arm architecture is not fully supported yet).