### PR TITLE
Use `Adam` instead of `ADAM`

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -90,7 +90,7 @@ The customizable, expanded version of the code looks like this:
 dls = taskdataloaders(data, task)
 model = taskmodel(task, Models.xresnet18())
 lossfn = tasklossfn(task)
-learner = Learner(model, dls, ADAM(), lossfn, ToGPU(), Metrics(accuracy))
+learner = Learner(model, dls, Adam(), lossfn, ToGPU(), Metrics(accuracy))
 ```
 
 At this step, we can also pass in any number of [callbacks](https://fluxml.ai/FluxTraining.jl/dev/docs/callbacks/reference.md.html) to customize the training. Here [`ToGPU`](#) ensures an available GPU is used, and [`Metrics`](#) adds additional metrics to track during training.

--- a/docs/learning_methods.md
+++ b/docs/learning_methods.md
@@ -176,7 +176,7 @@ model = Chain(
             Dense(512, length(task.classes)),
     )
 )
-optimizer = ADAM()
+optimizer = Adam()
 lossfn = Flux.Losses.logitcrossentropy
 
 learner = Learner(model, lossfn; data = (traindl, valdl), optimizer)

--- a/docs/notebooks/imagesegmentation.ipynb
+++ b/docs/notebooks/imagesegmentation.ipynb
@@ -479,7 +479,7 @@
    ],
    "source": [
     "traindl, validdl = taskdataloaders(data, task, 16)\n",
-    "optimizer = ADAM()\n",
+    "optimizer = Adam()\n",
     "learner = Learner(model, lossfn; data=(traindl, validdl), optimizer, callbacks=[ToGPU()])"
    ]
   },

--- a/docs/notebooks/keypointregression.ipynb
+++ b/docs/notebooks/keypointregression.ipynb
@@ -508,7 +508,7 @@
     "    model,\n",
     "    tasklossfn(task);\n",
     "    data=(traindl, validdl),\n",
-    "    optimizer=Flux.ADAM(),\n",
+    "    optimizer=Flux.Adam(),\n",
     "    callbacks=[ToGPU()])"
    ]
   },

--- a/docs/notebooks/siamese.ipynb
+++ b/docs/notebooks/siamese.ipynb
@@ -872,7 +872,7 @@
     {
      "data": {
       "text/plain": [
-       "ADAM(0.001, (0.9, 0.999), IdDict{Any, Any}())"
+       "Adam(0.001, (0.9, 0.999), IdDict{Any, Any}())"
       ]
      },
      "execution_count": 24,
@@ -882,7 +882,7 @@
    ],
    "source": [
     "lossfn = Flux.Losses.logitcrossentropy\n",
-    "optimizer = Flux.ADAM()"
+    "optimizer = Flux.Adam()"
    ]
   },
   {
@@ -965,7 +965,7 @@
     "h, w, ch, b = Flux.outputsize(encoder, (128, 128, 3, 1))\n",
     "head = Models.visionhead(2ch, 2)\n",
     "model = SiameseModel(encoder, head);\n",
-    "learner = Learner(model, (traindl, valdl), ADAM(0.01), lossfn, callbacks...)"
+    "learner = Learner(model, (traindl, valdl), Adam(0.01), lossfn, callbacks...)"
    ]
   },
   {

--- a/src/learner.jl
+++ b/src/learner.jl
@@ -13,7 +13,7 @@ Create a [`Learner`](#) to train a model for learning task `task` using
 - `backbone = nothing`: Backbone model to construct task-specific model from using
    [`taskmodel`](#)`(task, backbone)`.
 - `model = nothing`: Complete model to use. If given, the `backbone` argument is ignored.
-- `optimizer = ADAM()`: Optimizer passed to `Learner`.
+- `optimizer = Adam()`: Optimizer passed to `Learner`.
 - `lossfn = `[`tasklossfn`](#)`(task)`: Loss function passed to `Learner`.
 
 Any other keyword arguments will be passed to [`taskdataloaders`](#).
@@ -51,7 +51,7 @@ function tasklearner(task::LearningTask,
                      callbacks = [],
                      pctgval = 0.2,
                      batchsize = 16,
-                     optimizer = ADAM(),
+                     optimizer = Adam(),
                      lossfn = tasklossfn(task),
                      kwargs...)
     if isnothing(model)

--- a/src/training/onecycle.jl
+++ b/src/training/onecycle.jl
@@ -54,11 +54,11 @@ end
 # ## Tests
 
 @testset "decay_optim" begin
-    optim = ADAM()
+    optim = Adam()
     @test decay_optim(optim, 0.1) isa Optimiser
-    @test decay_optim(Optimiser(ADAM(), ADAM()), 0.1) isa Optimiser
+    @test decay_optim(Optimiser(Adam(), Adam()), 0.1) isa Optimiser
     @test decay_optim(optim, 0.1).os[1] isa WeightDecay
-    o = decay_optim(Optimiser(ADAM(), WeightDecay(0.5)), 0.1)
+    o = decay_optim(Optimiser(Adam(), WeightDecay(0.5)), 0.1)
     @test o.os[1] isa WeightDecay
-    @test o.os[2] isa ADAM
+    @test o.os[2] isa Adam
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,7 @@ using InlineTest
 using ..FastAI
 import ..FastAI: Block, Encoding, encodedblock, decodedblock, encode, decode,
                  testencoding, test_task_show, checkblock
-using Flux.Optimise: Optimiser, ADAM, apply!
+using Flux.Optimise: Optimiser, Adam, apply!
 
 ENV["DATADEPS_ALWAYS_ACCEPT"] = "true"
 include("testdata.jl")


### PR DESCRIPTION
The `ADAM` spelling was deprecated in a recent Flux.jl release, leading
to deprecation warnings which failed FastAI.jl's CI.