### PR TITLE
Fix UNet for 3D convolutions (specify ndim to convxlayer and ResBlock)

### DIFF
--- a/FastVision/src/models/unet.jl
+++ b/FastVision/src/models/unet.jl
@@ -142,5 +142,5 @@ end
     @test Flux.outputsize(model, (128, 128, 3, 1)) == (64, 64, 4, 1)
 
     model = UNetDynamic(Models.xresnet18(ndim = 3), (128, 128, 128, 3, 1), 4)
-    @test Flux.outputsize(model, (128, 128, 3, 1)) == (128, 128, 128, 4, 1)
+    @test Flux.outputsize(model, (128, 128, 128, 3, 1)) == (128, 128, 128, 4, 1)
 end end

--- a/FastVision/src/models/unet.jl
+++ b/FastVision/src/models/unet.jl
@@ -39,9 +39,9 @@ function UNetDynamic(backbone,
                       inputsize;
                       m_middle = UNetMiddleBlock,
                       skip_upscale = fdownscale,
-                      kwargs...)
+        kwargs...)
     outsz = Flux.outputsize(unet, inputsize)
-    return Chain(unet, final(outsz[end - 1], k_out))
+    return Chain(unet, final(outsz[end - 1], k_out, length(outsz) - 2))
 end
 
 function catchannels(x1, x2)
@@ -50,7 +50,7 @@ function catchannels(x1, x2)
 end
 
 function unetlayers(layers,
-                    sz;
+    sz;
                     k_out = nothing,
                     skip_upscale = 0,
                     m_middle = _ -> (identity,))
@@ -81,7 +81,8 @@ function unetlayers(layers,
         return UNetBlock(Chain(layer, childunet),
                          k_in,  # Input channels to upsampling layer
                          k_mid,
-                         k_out)
+                         k_out,
+                         length(outsz) - 2)
     end
 end
 
@@ -95,28 +96,28 @@ Given convolutional module `m` that halves the spatial dimensions
 and outputs `k_in` filters, create a module that upsamples the
 spatial dimensions and then aggregates features via  a skip connection.
 """
-function UNetBlock(m_child, k_in, k_mid, k_out = 2k_in)
+function UNetBlock(m_child, k_in, k_mid, k_out = 2k_in, ndim = 2)
     return Chain(upsample = SkipConnection(Chain(child = m_child,                              # Downsampling and processing
-                                                 upsample = PixelShuffleICNR(k_mid, k_mid)),
+                                                 upsample = PixelShuffleICNR(k_mid, k_mid, ndim)),
                                            Parallel(catchannels, identity, BatchNorm(k_in))),
                  act = xs -> relu.(xs),
-                 combine = UNetCombineLayer(k_in + k_mid, k_out))
+                 combine = UNetCombineLayer(k_in + k_mid, k_out, ndim))
 end
 
-function PixelShuffleICNR(k_in, k_out; r = 2)
-    return Chain(convxlayer(k_in, k_out * (r^2), ks = 1), Flux.PixelShuffle(r))
+function PixelShuffleICNR(k_in, k_out, ndim; r = 2)
+    return Chain(convxlayer(k_in, k_out * (r^ndim), ks = 1, ndim = ndim), Flux.PixelShuffle(r))
 end
 
-function UNetCombineLayer(k_in, k_out)
-    return Chain(convxlayer(k_in, k_out), convxlayer(k_out, k_out))
+function UNetCombineLayer(k_in, k_out, ndim)
+    return Chain(convxlayer(k_in, k_out, ndim = ndim), convxlayer(k_out, k_out, ndim = ndim))
 end
 
-function UNetMiddleBlock(k)
-    return Chain(convxlayer(k, 2k), convxlayer(2k, k))
+function UNetMiddleBlock(k, ndim)
+    return Chain(convxlayer(k, 2k, ndim = ndim), convxlayer(2k, k, ndim = ndim))
 end
 
-function UNetFinalBlock(k_in, k_out)
-    return Chain(ResBlock(1, k_in, k_in), convxlayer(k_in, k_out, ks = 1))
+function UNetFinalBlock(k_in, k_out, ndim)
+    return Chain(ResBlock(1, k_in, k_in, ndim = ndim), convxlayer(k_in, k_out, ks = 1, ndim = ndim))
 end
 
 """
@@ -139,4 +140,7 @@ end
 
     model = UNetDynamic(Models.xresnet18(), (128, 128, 3, 1), 4, fdownscale = 1)
     @test Flux.outputsize(model, (128, 128, 3, 1)) == (64, 64, 4, 1)
+
+    model = UNetDynamic(Models.xresnet18(ndim = 3), (128, 128, 128, 3, 1), 4)
+    @test Flux.outputsize(model, (128, 128, 3, 1)) == (128, 128, 128, 4, 1)
 end end


### PR DESCRIPTION
Fix the UNetDynamic creation for 3D images by specifying `ndim` to `convxlayer` and `ResBlock`. Also added a test to check the output size for a 3D UNet.

Now
```
julia> backbone = FastVision.Models.xresnet18(ndim=3);

julia> model = FastVision.Models.UNetDynamic(backbone, (128,128,128,3,1), 4);

julia> Flux.outputsize(model, (128, 128, 128, 3, 1)) == (128, 128, 128, 4, 1)
true
```


Previously:
```
julia> backbone = FastVision.Models.xresnet18(ndim=3);

julia> model = FastVision.Models.UNetDynamic(backbone, (128,128,128,3,1), 4);
┌ Error: layer SkipConnection(Chain(child = Chain(FastVision.Models.ResBlock(Chain(Chain(Conv((3, 3, 3), 256 => 512, pad=1, stride=2), BatchNorm(512, relu)), Chain(Conv((3, 3, 3), 512 => 512, pad=1), BatchNorm(512))), Chain(Conv((1, 1, 1), 256 => 512), BatchNorm(512, relu)), MeanPool((2, 2, 2))), Chain(FastVision.Models.ResBlock(Chain(Chain(Conv((3, 3, 3), 512 => 512, pad=1), BatchNorm(512, relu)), Chain(Conv((3, 3, 3), 512 => 512, pad=1), BatchNorm(512))), identity, identity), identity)), upsample = Chain(Chain(Conv((1, 1), 512 => 2048), BatchNorm(2048, relu)), PixelShuffle(2))), Parallel(catchannels, identity, BatchNorm(256))), index 2 in Chain, gave an error with input of size (8, 8, 8, 256, 1)
└ @ Flux ~/.julia/packages/Flux/4k0Ls/src/outputsize.jl:107
ERROR: DimensionMismatch: Rank of x and w must match! (5 vs. 4)
Stacktrace:
  [1] DenseConvDims(x::Array{Flux.NilNumber.Nil, 5}, w::Array{Float32, 4}; kwargs::Base.Pairs{Symbol, Any, NTuple{4, Symbol}, NamedTuple{(:stride, :padding, :dilation, :groups), Tuple{Tuple{Int64, Int64}, NTuple{4, Int64}, Tuple{Int64, Int64}, Int64}}})
    @ NNlib ~/.julia/packages/NNlib/0QnJJ/src/dim_helpers/DenseConvDims.jl:49
  [2] conv_dims(c::Conv{2, 4, typeof(identity), Array{Float32, 4}, Vector{Float32}}, x::Array{Flux.NilNumber.Nil, 5})
    @ Flux ~/.julia/packages/Flux/4k0Ls/src/layers/conv.jl:192
  [3] (::Conv{2, 4, typeof(identity), Array{Float32, 4}, Vector{Float32}})(x::Array{Flux.NilNumber.Nil, 5})
    @ Flux ~/.julia/packages/Flux/4k0Ls/src/layers/conv.jl:199
  [4] macro expansion
    @ ~/.julia/packages/Flux/4k0Ls/src/layers/basic.jl:53 [inlined]
  [5] _applychain(layers::Tuple{Conv{2, 4, typeof(identity), Array{Float32, 4}, Vector{Float32}}, BatchNorm{typeof(relu), Vector{Float32}, Float32, Vector{Float32}}}, x::Array{Flux.NilNumber.Nil, 5})
    @ Flux ~/.julia/packages/Flux/4k0Ls/src/layers/basic.jl:53
  [6] (::Chain{Tuple{Conv{2, 4, typeof(identity), Array{Float32, 4}, Vector{Float32}}, BatchNorm{typeof(relu), Vector{Float32}, Float32, Vector{Float32}}}})(x::Array{Flux.NilNumber.Nil, 5})
    @ Flux ~/.julia/packages/Flux/4k0Ls/src/layers/basic.jl:51
  [7] macro expansion
    @ ~/.julia/packages/Flux/4k0Ls/src/layers/basic.jl:53 [inlined]
  [8] _applychain(layers::Tuple{Chain{Tuple{Conv{2, 4, typeof(identity), Array{Float32, 4}, Vector{Float32}}, BatchNorm{typeof(relu), Vector{Float32}, Float32, Vector{Float32}}}}, PixelShuffle}, x::Array{Flux.NilNumber.Nil, 5})
    @ Flux ~/.julia/packages/Flux/4k0Ls/src/layers/basic.jl:53
  [9] (::Chain{Tuple{Chain{Tuple{Conv{2, 4, typeof(identity), Array{Float32, 4}, Vector{Float32}}, BatchNorm{typeof(relu), Vector{Float32}, Float32, Vector{Float32}}}}, PixelShuffle}})(x::Array{Flux.NilNumber.Nil, 5})
    @ Flux ~/.julia/packages/Flux/4k0Ls/src/layers/basic.jl:51
 [10] macro expansion
    @ ~/.julia/packages/Flux/4k0Ls/src/layers/basic.jl:53 [inlined]
 [11] _applychain(layers::Tuple{Chain{Tuple{FastVision.Models.ResBlock, Chain{Tuple{FastVision.Models.ResBlock, typeof(identity)}}}}, Chain{Tuple{Chain{Tuple{Conv{2, 4, typeof(identity), Array{Float32, 4}, Vector{Float32}}, BatchNorm{typeof(relu), Vector{Float32}, Float32, Vector{Float32}}}}, PixelShuffle}}}, x::Array{Flux.NilNumber.Nil, 5})
    @ Flux ~/.julia/packages/Flux/4k0Ls/src/layers/basic.jl:53
 [12] _applychain
    @ ~/.julia/packages/Flux/4k0Ls/src/layers/basic.jl:59 [inlined]
 [13] Chain
    @ ~/.julia/packages/Flux/4k0Ls/src/layers/basic.jl:51 [inlined]
 [14] (::SkipConnection{Chain{NamedTuple{(:child, :upsample), Tuple{Chain{Tuple{FastVision.Models.ResBlock, Chain{Tuple{FastVision.Models.ResBlock, typeof(identity)}}}}, Chain{Tuple{Chain{Tuple{Conv{2, 4, typeof(identity), Array{Float32, 4}, Vector{Float32}}, BatchNorm{typeof(relu), Vector{Float32}, Float32, Vector{Float32}}}}, PixelShuffle}}}}}, Parallel{typeof(FastVision.Models.catchannels), Tuple{typeof(identity), BatchNorm{typeof(identity), Vector{Float32}, Float32, Vector{Float32}}}}})(input::Array{Flux.NilNumber.Nil, 5})
    @ Flux ~/.julia/packages/Flux/4k0Ls/src/layers/basic.jl:344
 [15] outputsize(m::Chain{Tuple{FastVision.Models.ResBlock, SkipConnection{Chain{NamedTuple{(:child, :upsample), Tuple{Chain{Tuple{FastVision.Models.ResBlock, Chain{Tuple{FastVision.Models.ResBlock, typeof(identity)}}}}, Chain{Tuple{Chain{Tuple{Conv{2, 4, typeof(identity), Array{Float32, 4}, Vector{Float32}}, BatchNorm{typeof(relu), Vector{Float32}, Float32, Vector{Float32}}}}, PixelShuffle}}}}}, Parallel{typeof(FastVision.Models.catchannels), Tuple{typeof(identity), BatchNorm{typeof(identity), Vector{Float32}, Float32, Vector{Float32}}}}}, FastVision.Models.var"#94#95", Chain{Tuple{Chain{Tuple{Conv{2, 4, typeof(identity), Array{Float32, 4}, Vector{Float32}}, BatchNorm{typeof(relu), Vector{Float32}, Float32, Vector{Float32}}}}, Chain{Tuple{Conv{2, 4, typeof(identity), Array{Float32, 4}, Vector{Float32}}, BatchNorm{typeof(relu), Vector{Float32}, Float32, Vector{Float32}}}}}}}}, inputsizes::NTuple{5, Int64}; padbatch::Bool)
    @ Flux ~/.julia/packages/Flux/4k0Ls/src/outputsize.jl:104
 [16] outputsize(m::Chain{Tuple{FastVision.Models.ResBlock, SkipConnection{Chain{NamedTuple{(:child, :upsample), Tuple{Chain{Tuple{FastVision.Models.ResBlock, Chain{Tuple{FastVision.Models.ResBlock, typeof(identity)}}}}, Chain{Tuple{Chain{Tuple{Conv{2, 4, typeof(identity), Array{Float32, 4}, Vector{Float32}}, BatchNorm{typeof(relu), Vector{Float32}, Float32, Vector{Float32}}}}, PixelShuffle}}}}}, Parallel{typeof(FastVision.Models.catchannels), Tuple{typeof(identity), BatchNorm{typeof(identity), Vector{Float32}, Float32, Vector{Float32}}}}}, FastVision.Models.var"#94#95", Chain{Tuple{Chain{Tuple{Conv{2, 4, typeof(identity), Array{Float32, 4}, Vector{Float32}}, BatchNorm{typeof(relu), Vector{Float32}, Float32, Vector{Float32}}}}, Chain{Tuple{Conv{2, 4, typeof(identity), Array{Float32, 4}, Vector{Float32}}, BatchNorm{typeof(relu), Vector{Float32}, Float32, Vector{Float32}}}}}}}}, inputsizes::NTuple{5, Int64})
    @ Flux ~/.julia/packages/Flux/4k0Ls/src/outputsize.jl:100
 [17] unetlayers(layers::Vector{Any}, sz::NTuple{5, Int64}; k_out::Nothing, skip_upscale::Int64, m_middle::FastVision.Models.var"#91#93")
    @ FastVision.Models ~/.julia/dev/FastAI/FastVision/src/models/unet.jl:76
 [18] unetlayers(layers::Vector{Any}, sz::NTuple{5, Int64}; k_out::Nothing, skip_upscale::Int64, m_middle::FastVision.Models.var"#91#93")
    @ FastVision.Models ~/.julia/dev/FastAI/FastVision/src/models/unet.jl:66
 [19] unetlayers(layers::Vector{Any}, sz::NTuple{5, Int64}; k_out::Nothing, skip_upscale::Int64, m_middle::FastVision.Models.var"#91#93")
    @ FastVision.Models ~/.julia/dev/FastAI/FastVision/src/models/unet.jl:75
 [20] unetlayers(layers::Vector{Any}, sz::NTuple{5, Int64}; k_out::Nothing, skip_upscale::Int64, m_middle::FastVision.Models.var"#91#93") (repeats 2 times)
    @ FastVision.Models ~/.julia/dev/FastAI/FastVision/src/models/unet.jl:66
 [21] unetlayers(layers::Vector{Any}, sz::NTuple{5, Int64}; k_out::Nothing, skip_upscale::Int64, m_middle::FastVision.Models.var"#91#93")
    @ FastVision.Models ~/.julia/dev/FastAI/FastVision/src/models/unet.jl:75
 [22] unetlayers(layers::Vector{Any}, sz::NTuple{5, Int64}; k_out::Nothing, skip_upscale::Int64, m_middle::FastVision.Models.var"#91#93") (repeats 5 times)
    @ FastVision.Models ~/.julia/dev/FastAI/FastVision/src/models/unet.jl:66
 [23] unetlayers(layers::Vector{Any}, sz::NTuple{5, Int64}; k_out::Nothing, skip_upscale::Int64, m_middle::typeof(FastVision.Models.UNetMiddleBlock))
    @ FastVision.Models ~/.julia/dev/FastAI/FastVision/src/models/unet.jl:75
 [24] UNetDynamic(backbone::Chain{Tuple{Chain{Tuple{Conv{3, 6, typeof(identity), Array{Float32, 5}, Vector{Float32}}, BatchNorm{typeof(relu), Vector{Float32}, Float32, Vector{Float32}}}}, Chain{Tuple{Conv{3, 6, typeof(identity), Array{Float32, 5}, Vector{Float32}}, BatchNorm{typeof(relu), Vector{Float32}, Float32, Vector{Float32}}}}, Chain{Tuple{Conv{3, 6, typeof(identity), Array{Float32, 5}, Vector{Float32}}, BatchNorm{typeof(relu), Vector{Float32}, Float32, Vector{Float32}}}}, MaxPool{3, 6}, Chain{Tuple{FastVision.Models.ResBlock, FastVision.Models.ResBlock}}, Chain{Tuple{FastVision.Models.ResBlock, FastVision.Models.ResBlock}}, Chain{Tuple{FastVision.Models.ResBlock, FastVision.Models.ResBlock}}, Chain{Tuple{FastVision.Models.ResBlock, FastVision.Models.ResBlock}}}}, inputsize::NTuple{5, Int64}, k_out::Int64; final::typeof(FastVision.Models.UNetFinalBlock), fdownscale::Int64, kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
    @ FastVision.Models ~/.julia/dev/FastAI/FastVision/src/models/unet.jl:38
 [25] UNetDynamic(backbone::Chain{Tuple{Chain{Tuple{Conv{3, 6, typeof(identity), Array{Float32, 5}, Vector{Float32}}, BatchNorm{typeof(relu), Vector{Float32}, Float32, Vector{Float32}}}}, Chain{Tuple{Conv{3, 6, typeof(identity), Array{Float32, 5}, Vector{Float32}}, BatchNorm{typeof(relu), Vector{Float32}, Float32, Vector{Float32}}}}, Chain{Tuple{Conv{3, 6, typeof(identity), Array{Float32, 5}, Vector{Float32}}, BatchNorm{typeof(relu), Vector{Float32}, Float32, Vector{Float32}}}}, MaxPool{3, 6}, Chain{Tuple{FastVision.Models.ResBlock, FastVision.Models.ResBlock}}, Chain{Tuple{FastVision.Models.ResBlock, FastVision.Models.ResBlock}}, Chain{Tuple{FastVision.Models.ResBlock, FastVision.Models.ResBlock}}, Chain{Tuple{FastVision.Models.ResBlock, FastVision.Models.ResBlock}}}}, inputsize::NTuple{5, Int64}, k_out::Int64)
    @ FastVision.Models ~/.julia/dev/FastAI/FastVision/src/models/unet.jl:31
 [26] top-level scope
    @ REPL[103]:1
 [27] top-level scope
    @ ~/.julia/packages/CUDA/DfvRa/src/initialization.jl:52
```

### PR Checklist

- [x] Tests are added
- [x] Documentation, if applicable
