### PR TITLE
Bugfix: Export `ConvFeatures`. Required for FastTimm.jl

### DIFF
--- a/FastVision/src/FastVision.jl
+++ b/FastVision/src/FastVision.jl
@@ -114,7 +114,7 @@ function __init__()
     end
 end
 
-export Image, Mask, Keypoints, Bounded,
+export Image, Mask, Keypoints, Bounded, ConvFeatures,
 # encodings
        ImagePreprocessing, KeypointPreprocessing, ProjectiveTransforms,
 # learning tasks


### PR DESCRIPTION
Currently, when following the instructions posted [here](https://julialang.zulipchat.com/#narrow/stream/237432-ml-contributers/topic/Training.20PyTorch.20models.20in.20Julia/near/326305865), using `FastTimm.jl` fails because `FastVision` doesn't export `ConvFeatures`. We fix that here.

```julia
(DisentanglingVAE) pkg> precompile
Precompiling environment...
  ✗ FastTimm
  8 dependencies successfully precompiled in 169 seconds. 251 already precompiled.

ERROR: The following 1 direct dependency failed to precompile:

FastTimm [6fe279a3-76fd-4f59-807e-d8e68e6f60cf]

Failed to precompile FastTimm [6fe279a3-76fd-4f59-807e-d8e68e6f60cf] to "/home/romeo/.
julia/compiled/v1.9/FastTimm/jl_bv8rcW".
ERROR: LoadError: UndefVarError: `ConvFeatures` not defined
Stacktrace:
 [1] include
   @ ./Base.jl:456 [inlined]
 [2] include_package_for_output(pkg::Base.PkgId, input::String, depot_path::Vector{Str
ing}, dl_load_path::Vector{String}, load_path::Vector{String}, concrete_deps::Vector{P
air{Base.PkgId, UInt128}}, source::Nothing)
   @ Base ./loading.jl:1952
 [3] top-level scope
   @ stdin:2
in expression starting at /home/romeo/.julia/packages/FastTimm/kKGs7/src/FastTimm.jl:1
in expression starting at stdin:2

```

By running
```bash
$ pwd
# <...>/FastAI.jl/FastVision
$ rg "^struct " src/blocks/
```
we can check if there's any other blocks we forgot to export, which doesn't seem to be the case.
