### PR TITLE
Remove extra type parameter

### DIFF
--- a/src/encodings/onehot.jl
+++ b/src/encodings/onehot.jl
@@ -34,7 +34,7 @@ function checkblock(block::OneHotTensorMulti{N}, a::AbstractArray{T, M}) where {
     return N + 1 == M && last(size(a)) == length(block.classes)
 end
 
-function mockblock(block::OneHotTensorMulti{0}) where {N}
+function mockblock(block::OneHotTensorMulti{0})
     labelblock = LabelMulti(block.classes)
     return encode(OneHot(), Validation(), labelblock, mockblock(labelblock))
 end


### PR DESCRIPTION
This is a super simple PR to remove an extraneous type parameter that throws a warning on Julia 1.9>=.

Here's the relevant error:

```
┌ FastAI [5d0beca9-ade8-49ae-ad0b-a3cf890e669f]
│  WARNING: method definition for mockblock at /home/cameron/.julia/packages/FastAI/f27xT/src/encodings/onehot.jl:37 declares type variable N but does not use it.
└  
```
